### PR TITLE
Fix some lint errors and fix the build command callback.

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -48,9 +48,10 @@ module.exports = function (Aquifer) {
           //fs.symlinkSync(path.join(self.destination, 'sites/all/modules/custom'), self.project.absolutePaths.modules.contrib, 'directory');
           //fs.symlinkSync(path.join(self.destination, 'sites/all/modules/features'), self.project.absolutePaths.modules.features, 'directory');
         });
-      });
-    }
+      })
+      .then(callback);
+    };
   };
 
   return Build;
-}
+};

--- a/lib/build.command.js
+++ b/lib/build.command.js
@@ -10,9 +10,7 @@ module.exports = function (Aquifer) {
   'use strict';
 
   /**
-   * Define the 'create <name>' command.
-   *
-   * @param String directory directory in which aquifer should be initialized.
+   * Define the 'build' command.
    */
   Aquifer.cli.command('build')
   .description('Builds a Drupal site in the /builds/work directory.')
@@ -41,7 +39,7 @@ module.exports = function (Aquifer) {
         Aquifer.console.log(error, 'error');
       }
       else {
-        Aquifer.console.log(self.name + ' build created successfully!', 'success');
+        Aquifer.console.log(project.name + ' build created successfully!', 'success');
       }
     });
   });

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -58,7 +58,7 @@ module.exports = function (Aquifer) {
         self.json = jsonFile.readFileSync(configJsonPath);
         self.relativePaths = self.json.paths;
       }
-    };
+    }
 
     // Define absolute paths to assets.
     self.absolutePaths = {


### PR DESCRIPTION
I left lint errors about unused variables since I figured there might be plans to use them in the future.

You should see a `<project name> build created successfully!` message after a successful build now.
