### PR TITLE
Settings Directory

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -76,12 +76,59 @@ module.exports = function (Aquifer) {
         }))
         // Create symlinks.
         .then(buildStep('Creating symlinks...', function () {
-          return promise.all([
-            promise.whenPromise(fs.symlinkSync(self.project.absolutePaths.settings, path.join(self.destination, 'sites/default/site.settings.php'), 'file')),
-            promise.whenPromise(fs.symlinkSync(self.project.absolutePaths.modules.custom, path.join(self.destination, 'sites/all/modules/custom'),  'dir')),
-            promise.whenPromise(fs.symlinkSync(self.project.absolutePaths.modules.features, path.join(self.destination, 'sites/all/modules/features'),  'dir')),
-            promise.whenPromise(fs.symlinkSync(self.project.absolutePaths.themes.custom, path.join(self.destination, 'sites/all/themes/custom'),  'dir'))
-          ]);
+          var symlinks = [],
+              promises = [];
+
+          // Add custom modules symlink.
+          symlinks.push({
+            src: self.project.absolutePaths.modules.custom,
+            dest: path.join(self.destination, 'sites/all/modules/custom'),
+            type: 'dir'
+          });
+
+          // Add features symlink.
+          symlinks.push({
+            src: self.project.absolutePaths.modules.features,
+            dest: path.join(self.destination, 'sites/all/modules/features'),
+            type: 'dir'
+          });
+
+          // Add custom themes symlink.
+          symlinks.push({
+            src: self.project.absolutePaths.themes.custom,
+            dest: path.join(self.destination, 'sites/all/themes/custom'),
+            type: 'dir'
+          });
+
+          // Add settings files symlinks.
+          fs.readdirSync(self.project.absolutePaths.settings)
+            .filter(function (file) {
+              return file.indexOf('.') !== 0;
+            })
+            .forEach(function (file) {
+              symlinks.push({
+                src: path.join(self.project.absolutePaths.settings, file),
+                dest: path.join(self.destination, 'sites/default', file),
+                type: 'file'
+              });
+            });
+
+          // Create a promise for each symlink creation.
+          promises = symlinks.map(function (link) {
+            var def = new Deferred();
+
+            fs.symlink(link.src, link.dest, link.type, function (err) {
+              if (err) {
+                return def.reject(err);
+              }
+              def.resolve();
+            });
+
+            return def.promise;
+          });
+
+          // Return a promise for the completed creation of all symlinks.
+          return promise.all(promises);
         }))
         // Complete the build promise chain.
         .then(function (res) {

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -20,8 +20,7 @@ module.exports = function (Aquifer) {
         path      = require('path'),
         drush     = require('drush-node'),
         promise   = require('promised-io/promise'),
-        Deferred  = promise.Deferred,
-        q         = require('q');
+        Deferred  = promise.Deferred;
 
     self.destination = destination;
     self.project = project;

--- a/lib/build.command.js
+++ b/lib/build.command.js
@@ -16,7 +16,6 @@ module.exports = function (Aquifer) {
   .description('Builds a Drupal site in the /builds/work directory.')
   .action(function () {
     var path      = require('path'),
-        fs        = require('fs-extra'),
         jsonFile  = require('jsonfile'),
         jsonPath  = path.join(Aquifer.projectDir, 'aquifer.json'),
         make, json, project, build, directory;

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -33,7 +33,7 @@ module.exports = function (Aquifer) {
     // Set default relative paths.
     self.relativePaths = {
       make: 'drupal.make',
-      settings: 'site.settings.php',
+      settings: 'settings',
       builds: 'builds/',
       themes: {
         root: 'themes/',
@@ -101,6 +101,7 @@ module.exports = function (Aquifer) {
       // Create root, modules, builds, and themes folders.
       fs.mkdirSync(self.directory);
       fs.mkdirSync(self.absolutePaths.builds);
+      fs.mkdirSync(self.absolutePaths.settings);
       fs.mkdirSync(self.absolutePaths.themes.root);
       fs.mkdirSync(self.absolutePaths.themes.custom);
       fs.mkdirSync(self.absolutePaths.modules.root);
@@ -113,9 +114,10 @@ module.exports = function (Aquifer) {
       touch.sync(path.join(self.absolutePaths.themes.root, '.gitkeep'));
       touch.sync(path.join(self.absolutePaths.themes.custom, '.gitkeep'));
       touch.sync(path.join(self.absolutePaths.builds, '.gitkeep'));
+      touch.sync(path.join(self.absolutePaths.settings, '.gitkeep'));
 
       // Copy over src files.
-      fs.copySync(path.join(srcDir, 'site.settings.php'), self.absolutePaths.settings);
+      fs.copySync(path.join(srcDir, 'site.settings.php'), path.join(self.absolutePaths.settings, 'site.settings.php'));
       fs.copySync(path.join(srcDir, 'drupal.make'), self.absolutePaths.make);
       fs.copySync(path.join(srcDir, 'gitignore'), path.join(self.directory, '.gitignore'));
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "lodash": "^3.6.0",
     "path": "^0.11.14",
     "promised-io": "^0.3.5",
-    "q": "^1.4.0",
     "touch": "0.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
**Changes:**
- `settings` directory is now included when creating new projects and every file in that directory not starting with a period is symlinked to `sites/default/<filename>` in the build.
- Fixed symlink creation to be truly asynchronous.
- Removed q since we are already making heavy use of promised-io and that's what drush-node uses for promises.
- Removed fs from build.command.js since we are unlikely to use it there and it causes lint errors.

**To Review:**
1. Create a new project and verify it has a settings directory.
2. Build that project and verify all the files in the settings directory are symlinked in `sites/default` within the build.
