### PR TITLE
Refresh

### DIFF
--- a/aquifer.js
+++ b/aquifer.js
@@ -10,7 +10,7 @@
  *  \__,_|\__, |\__,_|_|_|  \___|_|
  *           |_|
  */
-/* globals require */
+/* globals require, process */
 
 var Aquifer = {};
 Aquifer.console = require('./lib/console.api.js')(Aquifer);
@@ -20,12 +20,14 @@ Aquifer.init.setup();
 // APIs.
 Aquifer.project = require('./lib/project.api.js')(Aquifer);
 Aquifer.build = require('./lib/build.api.js')(Aquifer);
+Aquifer.refresh = require('./lib/refresh.api.js')(Aquifer);
 
 // Commands.
 Aquifer.commands = {
   create: require('./lib/create.command.js')(Aquifer),
-  build: require('./lib/build.command.js')(Aquifer)
-}
+  build: require('./lib/build.command.js')(Aquifer),
+  refresh: require('./lib/refresh.command.js')(Aquifer)
+};
 
 // If no arguments passed in, output cli docs. Else parse.
 if (!process.argv.slice(2).length) {

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -71,7 +71,7 @@ module.exports = function (Aquifer) {
         }))
         // Run drush make.
         .then(buildStep('Executing drush make...', function () {
-          return drush.exec('make ' + make + ' ' + self.destination);
+          return drush.spawn(['make', make, self.destination]);
         }))
         // Create symlinks.
         .then(buildStep('Creating symlinks...', function () {

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -64,14 +64,14 @@ module.exports = function (Aquifer) {
       };
 
       // Initialize drush and the build promise chain.
-      drush.init()
+      drush.init({log: true})
         // Delete current build.
         .then(buildStep('Removing possible existing build...', function () {
           fs.removeSync(self.destination);
         }))
         // Run drush make.
         .then(buildStep('Executing drush make...', function () {
-          return drush.spawn(['make', make, self.destination]);
+          return drush.exec(['make', make, self.destination]);
         }))
         // Create symlinks.
         .then(buildStep('Creating symlinks...', function () {

--- a/lib/build.command.js
+++ b/lib/build.command.js
@@ -15,16 +15,16 @@ module.exports = function (Aquifer) {
   Aquifer.cli.command('build')
   .description('Builds a Drupal site in the /builds/work directory.')
   .action(function () {
-    var path      = require('path'),
-        jsonFile  = require('jsonfile'),
-        jsonPath  = path.join(Aquifer.projectDir, 'aquifer.json'),
-        make, json, project, build, directory;
-
     // If the current directory doesn't contain an aquifer project, exit.
     if (!Aquifer.initialized) {
       Aquifer.console.log('You are not currently in directory that contains an Aquifer project.', 'error');
       return;
     }
+
+    var path      = require('path'),
+        jsonFile  = require('jsonfile'),
+        jsonPath  = path.join(Aquifer.projectDir, 'aquifer.json'),
+        make, json, project, build, directory;
 
     // load json settings file.
     json = jsonFile.readFileSync(jsonPath);

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -95,7 +95,15 @@ module.exports = function (Aquifer) {
       var srcDir      = path.join(path.dirname(fs.realpathSync(__filename)), '../src'),
           aquiferJson = {
             name: self.name,
-            paths: self.relativePaths
+            paths: self.relativePaths,
+            refreshCommands: [
+              ['updb'],
+              ['cc', 'all'],
+              ['en', 'master'],
+              ['master-execute', '--scope=local'],
+              ['fra'],
+              ['rr']
+            ]
           };
 
       // Create root, modules, builds, and themes folders.

--- a/lib/refresh.api.js
+++ b/lib/refresh.api.js
@@ -29,7 +29,7 @@ module.exports = function (Aquifer) {
 
     commands.forEach(function (args) {
       functions.push(function() {
-        return drush.spawn(location.concat(args));
+        return drush.exec(location.concat(args), {log: true});
       });
     });
 

--- a/lib/refresh.api.js
+++ b/lib/refresh.api.js
@@ -1,0 +1,46 @@
+/**
+ * @file
+ * Refreshes the site against the current state of its codebase.
+ */
+
+/* globals require, module */
+
+module.exports = function (Aquifer) {
+  'use strict';
+
+  /**
+   * Refreshes the site against the current state of its codebase.
+   *
+   * @param {string} target Either a site alias for running the command remotely or a directory for running it locally.
+   * @param {array} commands An array of drush commands which are each an array of arguments. e.g. ['cc', 'drush'].
+   * @param {funciton} callback called when process finishes executing or errors out.
+   */
+  var refresh = function (target, commands, callback) {
+    // If project isn't initialized (doesn't exist) then exit.
+    if (!Aquifer.initialized) {
+      callback('Cannot build a project that hasn\'t been initialized.');
+      return;
+    }
+
+    var drush     = require('drush-node'),
+        promise   = require('promised-io/promise'),
+        location  = target.indexOf('@') === 0 ? [target] : ['-r', target],
+        functions = [drush.init];
+
+    commands.forEach(function (args) {
+      functions.push(function() {
+        return drush.spawn(location.concat(args));
+      });
+    });
+
+    promise.seq(functions)
+      .then(function () {
+        callback();
+      },
+      function (err) {
+        callback(err);
+      });
+  };
+
+  return refresh;
+};

--- a/lib/refresh.command.js
+++ b/lib/refresh.command.js
@@ -1,0 +1,42 @@
+/**
+ * @file
+ * Defines 'aquifer refresh' cli.
+ */
+
+
+/* globals require, module */
+
+module.exports = function (Aquifer) {
+  'use strict';
+
+  /**
+   * Define the 'refresh' command.
+   */
+  Aquifer.cli.command('refresh')
+  .description('Refreshes a site against the current state of its codebase.')
+  .option('-a, --drupalAlias <alias>', 'Optional alias for the target site.')
+  .action(function (options) {
+    // If the current directory doesn't contain an aquifer project, exit.
+    if (!Aquifer.initialized) {
+      Aquifer.console.log('You are not currently in directory that contains an Aquifer project.', 'error');
+      return;
+    }
+
+    var path      = require('path'),
+        jsonFile  = require('jsonfile'),
+        jsonPath  = path.join(Aquifer.projectDir, 'aquifer.json'),
+        json      = jsonFile.readFileSync(jsonPath),
+        project   = new Aquifer.project(Aquifer.projectDir, json.name),
+        target    = options.drupalAlias ? options.drupalAlias : path.join(Aquifer.projectDir, json.paths.builds, 'work'),
+        name      = options.drupalAlias ? options.drupalAlias : project.name;
+
+    Aquifer.refresh(target, json.refreshCommands, function(error) {
+      if (error) {
+        Aquifer.console.log(error, 'error');
+      }
+      else {
+        Aquifer.console.log('All refresh commands run for ' + name, 'success');
+      }
+    });
+  });
+};

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "commander": "^2.7.1",
-    "drush-node": "^0.1.3",
+    "drush-node": "chasingmaxwell/drush-node",
     "fs-extra": "^0.18.0",
     "jsonfile": "^2.0.0",
     "lodash": "^3.6.0",


### PR DESCRIPTION
**Changes:**
- Adds the refresh api and command.
- Uses my fork of drush-node (temporarily) so we can make use of the new spawn method which logs stdout and stderr so we can see the output of the drush commands we run.

**To Review:**
1. Run `npm update drush-node` from the aquifer root.
2. Create and build a project.
3. Install Drupal for the built codebase (manually by adding a $databases array to settings.php, creating the necessary table and user in mysql and running drush si).
4. Run `aquifer refresh` and verify that all the sensible drush commands are run to refresh the site against the state of its codebase.
