### PR TITLE
API Cleanup

### DIFF
--- a/bin/aquifer.js
+++ b/bin/aquifer.js
@@ -15,15 +15,19 @@
 var Aquifer = {};
 Aquifer.console = require('../lib/console.api.js')(Aquifer);
 Aquifer.init = require('../lib/init.api.js')(Aquifer);
-Aquifer.init.setup();
 
 // APIs.
-Aquifer.project = require('../lib/project.api.js')(Aquifer);
-Aquifer.build = require('../lib/build.api.js')(Aquifer);
-Aquifer.refresh = require('../lib/refresh.api.js')(Aquifer);
+Aquifer.api = {
+  project: require('../lib/project.api.js')(Aquifer),
+  build: require('../lib/build.api.js')(Aquifer),
+  refresh: require('../lib/refresh.api.js')(Aquifer)
+}
+
+// Initialize.
+Aquifer.init.setup();
 
 // Commands.
-Aquifer.commands = {
+Aquifer.command = {
   create: require('../lib/create.command.js')(Aquifer),
   build: require('../lib/build.command.js')(Aquifer),
   refresh: require('../lib/refresh.command.js')(Aquifer)

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -11,10 +11,9 @@ module.exports = function (Aquifer) {
   /**
    * Creates a build object from which operations can be initiated.
    *
-   * @param object project object of project that should be built.
    * @param string destination path to destination folder.
    */
-  var Build = function(project, destination) {
+  var Build = function(destination) {
     var self      = this,
         fs        = require('fs-extra'),
         path      = require('path'),
@@ -23,7 +22,6 @@ module.exports = function (Aquifer) {
         Deferred  = promise.Deferred;
 
     self.destination = destination;
-    self.project = project;
 
     /**
      * Creates a Drupal root in specified directory.
@@ -80,33 +78,33 @@ module.exports = function (Aquifer) {
 
           // Add custom modules symlink.
           symlinks.push({
-            src: self.project.absolutePaths.modules.custom,
+            src: Aquifer.project.absolutePaths.modules.custom,
             dest: path.join(self.destination, 'sites/all/modules/custom'),
             type: 'dir'
           });
 
           // Add features symlink.
           symlinks.push({
-            src: self.project.absolutePaths.modules.features,
+            src: Aquifer.project.absolutePaths.modules.features,
             dest: path.join(self.destination, 'sites/all/modules/features'),
             type: 'dir'
           });
 
           // Add custom themes symlink.
           symlinks.push({
-            src: self.project.absolutePaths.themes.custom,
+            src: Aquifer.project.absolutePaths.themes.custom,
             dest: path.join(self.destination, 'sites/all/themes/custom'),
             type: 'dir'
           });
 
           // Add settings files symlinks.
-          fs.readdirSync(self.project.absolutePaths.settings)
+          fs.readdirSync(Aquifer.project.absolutePaths.settings)
             .filter(function (file) {
               return file.indexOf('.') !== 0;
             })
             .forEach(function (file) {
               symlinks.push({
-                src: path.join(self.project.absolutePaths.settings, file),
+                src: path.join(Aquifer.project.absolutePaths.settings, file),
                 dest: path.join(self.destination, 'sites/default', file),
                 type: 'file'
               });

--- a/lib/build.command.js
+++ b/lib/build.command.js
@@ -30,15 +30,14 @@ module.exports = function (Aquifer) {
     json = jsonFile.readFileSync(jsonPath);
     directory = path.join(Aquifer.projectDir, json.paths.builds, 'work');
     make = path.join(Aquifer.projectDir, json.paths.make);
-    project = new Aquifer.project(Aquifer.projectDir, json.name);
-    build = new Aquifer.build(project, directory);
+    build = new Aquifer.api.build(directory);
 
     build.create(make, function(error) {
       if (error) {
         Aquifer.console.log(error, 'error');
       }
       else {
-        Aquifer.console.log(project.name + ' build created successfully!', 'success');
+        Aquifer.console.log(Aquifer.project.name + ' build created successfully!', 'success');
       }
     });
   });

--- a/lib/build.command.js
+++ b/lib/build.command.js
@@ -9,18 +9,18 @@
 module.exports = function (Aquifer) {
   'use strict';
 
+  // If the current directory doesn't contain an aquifer project, exit.
+  if (!Aquifer.initialized) {
+    return;
+  }
+
+
   /**
    * Define the 'build' command.
    */
   Aquifer.cli.command('build')
   .description('Builds a Drupal site in the /builds/work directory.')
   .action(function () {
-    // If the current directory doesn't contain an aquifer project, exit.
-    if (!Aquifer.initialized) {
-      Aquifer.console.log('You are not currently in directory that contains an Aquifer project.', 'error');
-      return;
-    }
-
     var path      = require('path'),
         jsonFile  = require('jsonfile'),
         jsonPath  = path.join(Aquifer.projectDir, 'aquifer.json'),
@@ -37,7 +37,7 @@ module.exports = function (Aquifer) {
         Aquifer.console.log(error, 'error');
       }
       else {
-        Aquifer.console.log(Aquifer.project.name + ' build created successfully!', 'success');
+        Aquifer.console.log(Aquifer.project.config.name + ' build created successfully!', 'success');
       }
     });
   });

--- a/lib/build.command.js
+++ b/lib/build.command.js
@@ -24,7 +24,7 @@ module.exports = function (Aquifer) {
     var path      = require('path'),
         jsonFile  = require('jsonfile'),
         jsonPath  = path.join(Aquifer.projectDir, 'aquifer.json'),
-        make, json, project, build, directory;
+        make, json, build, directory;
 
     // load json settings file.
     json = jsonFile.readFileSync(jsonPath);

--- a/lib/create.command.js
+++ b/lib/create.command.js
@@ -23,13 +23,7 @@ module.exports = function (Aquifer) {
         directory   = path.join(Aquifer.cwd, name),
         project     = {};
 
-    if (configFile) {
-      project = new Aquifer.project(directory, name, configFile);
-    }
-    else {
-      project = new Aquifer.project(directory, name);
-    }
-
+    project = new Aquifer.api.project(directory, name, configFile);
     project.create(function(error) {
       if (error) {
         Aquifer.console.log(error, 'error');

--- a/lib/init.api.js
+++ b/lib/init.api.js
@@ -28,7 +28,6 @@ module.exports = function (Aquifer) {
     while (Aquifer.projectDir === false && dir.length > 0) {
       if (fs.existsSync(dir + '/aquifer.json')) {
         Aquifer.project = new Aquifer.api.project(dir);
-        console.log(Aquifer.project);
         Aquifer.initialized = true;
         Aquifer.projectDir = dir;
       }

--- a/lib/init.api.js
+++ b/lib/init.api.js
@@ -27,6 +27,8 @@ module.exports = function (Aquifer) {
     dir = Aquifer.cwd;
     while (Aquifer.projectDir === false && dir.length > 0) {
       if (fs.existsSync(dir + '/aquifer.json')) {
+        Aquifer.project = new Aquifer.api.project(dir);
+        console.log(Aquifer.project);
         Aquifer.initialized = true;
         Aquifer.projectDir = dir;
       }

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -12,71 +12,63 @@ module.exports = function (Aquifer) {
    * Defines the Project object.
    *
    * @param string directory working directory of project.
-   * @param string name name of project;
+   * @param string name name of project.
+   * @param string configJsonPath path to json file that should extend default aquifer.json.
    */
   var Project = function(directory, name, configJsonPath) {
     var self      = this,
+        _         = require('lodash'),
         fs        = require('fs-extra'),
         path      = require('path'),
         touch     = require('touch'),
         jsonFile  = require('jsonfile'),
-        jsonPath  = path.join(directory, 'aquifer.json');
+        jsonPath  = path.join(directory, 'aquifer.json'),
+        srcDir    = path.join(path.dirname(fs.realpathSync(__filename)), '../src');
 
 
-    // Set directory, name, and status.
-    self.directory = directory;
-    self.name = name;
+
+    // Set directory, name, and status. Directory is required!
+    self.directory = directory ||  Aquifer.cwd;
 
     // Decide whether or not this is initialized already.
     self.initialized = fs.existsSync(self.directory) || fs.existsSync(jsonPath) ? true : false;
 
-    // Set default relative paths.
-    self.relativePaths = {
-      make: 'drupal.make',
-      settings: 'settings',
-      builds: 'builds/',
-      themes: {
-        root: 'themes/',
-        contrib: 'themes/contrib',
-        custom: 'themes/custom'
-      },
-      modules: {
-        root: 'modules',
-        contrib: 'modules/contrib',
-        custom: 'modules/custom',
-        features: 'modules/features'
-      }
-    };
-
-    // If this project already exists, then read aquifer json to define relative paths.
+    // If this project is initialized, load the JSON path.
     if (self.initialized) {
-      self.json = jsonFile.readFileSync(jsonPath);
-      self.relativePaths = self.json.paths;
+      self.config = jsonFile.readFileSync(jsonPath);
     }
-    // If a config json file was passed in, use it to set paths.
+    // If this is a new (uninitialized) project, load the default json.
     else {
-      if (configJsonPath) {
-        self.json = jsonFile.readFileSync(configJsonPath);
-        self.relativePaths = self.json.paths;
-      }
+      self.config = jsonFile.readFileSync(path.join(srcDir, 'aquifer.default.json'));
+    }
+
+    // If a config json path was passed in, extend the default.
+    if (configJsonPath) {
+      var configJson = jsonFile.readFileSync(configJsonPath);
+      _.extend(self.config, configJson);
+    }
+
+    // Set name, default to basename of directory.
+    if (!self.config.name || self.config.name.length <= 0){
+      self.config.name = name || self.path.basename(directory);
     }
 
     // Define absolute paths to assets.
     self.absolutePaths = {
       json: jsonPath,
-      make: path.join(self.directory, self.relativePaths.make),
-      settings: path.join(self.directory, self.relativePaths.settings),
-      builds: path.join(self.directory, self.relativePaths.builds),
+      make: path.join(self.directory, self.config.paths.make),
+      settings: path.join(self.directory, self.config.paths.settings),
+      builds: path.join(self.directory, self.config.paths.builds),
       themes: {
-        root: path.join(self.directory, self.relativePaths.themes.root),
-        contrib: path.join(self.directory, self.relativePaths.themes.contrib),
-        custom: path.join(self.directory, self.relativePaths.themes.custom)
+        root: path.join(self.directory, self.config.paths.themes.root),
+        contrib: path.join(self.directory, self.config.paths.themes.contrib),
+        custom: path.join(self.directory, self.config.paths.themes.custom)
       },
       modules: {
-        root: path.join(self.directory, self.relativePaths.modules.root),
-        contrib: path.join(self.directory, self.relativePaths.modules.contrib),
-        custom: path.join(self.directory, self.relativePaths.modules.custom),
-        features: path.join(self.directory, self.relativePaths.modules.features)
+        root: path.join(self.directory, self.config.paths.modules.root),
+        contrib: path.join(self.directory, self.config.paths.modules.contrib),
+        custom: path.join(self.directory, self.config.paths.modules.custom),
+        features: path.join(self.directory, self.config.paths.modules.features)
       }
     };
 
@@ -91,20 +83,6 @@ module.exports = function (Aquifer) {
         callback(self.directory + ' already exists, or is already an aquifer project.');
         return;
       }
-
-      var srcDir      = path.join(path.dirname(fs.realpathSync(__filename)), '../src'),
-          aquiferJson = {
-            name: self.name,
-            paths: self.relativePaths,
-            refreshCommands: [
-              ['updb'],
-              ['cc', 'all'],
-              ['en', 'master'],
-              ['master-execute', '--scope=local'],
-              ['fra'],
-              ['rr']
-            ]
-          };
 
       // Create root, modules, builds, and themes folders.
       fs.mkdirSync(self.directory);
@@ -130,7 +108,7 @@ module.exports = function (Aquifer) {
       fs.copySync(path.join(srcDir, 'gitignore'), path.join(self.directory, '.gitignore'));
 
       // Create aquifer.json file.
-      jsonFile.writeFileSync(self.absolutePaths.json, aquiferJson);
+      jsonFile.writeFileSync(self.absolutePaths.json, self.config);
 
       callback(false);
     };

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -49,8 +49,8 @@ module.exports = function (Aquifer) {
     }
 
     // Set name, default to basename of directory.
-    if (!self.config.name || self.config.name.length <= 0){
-      self.config.name = name || self.path.basename(directory);
+    if (!self.config.name || self.config.name.length <= 0) {
+      self.config.name = name || path.basename(directory);
     }
 
     // Define absolute paths to assets.

--- a/lib/refresh.api.js
+++ b/lib/refresh.api.js
@@ -12,10 +12,9 @@ module.exports = function (Aquifer) {
    * Refreshes the site against the current state of its codebase.
    *
    * @param {string} target Either a site alias for running the command remotely or a directory for running it locally.
-   * @param {array} commands An array of drush commands which are each an array of arguments. e.g. ['cc', 'drush'].
    * @param {funciton} callback called when process finishes executing or errors out.
    */
-  var refresh = function (target, commands, callback) {
+  var refresh = function (target, callback) {
     // If project isn't initialized (doesn't exist) then exit.
     if (!Aquifer.initialized) {
       callback('Cannot build a project that hasn\'t been initialized.');
@@ -27,7 +26,7 @@ module.exports = function (Aquifer) {
         location  = target.indexOf('@') === 0 ? [target] : ['-r', target],
         functions = [drush.init];
 
-    commands.forEach(function (args) {
+    Aquifer.project.config.refreshCommands.forEach(function (args) {
       functions.push(function() {
         return drush.exec(location.concat(args), {log: true});
       });

--- a/lib/refresh.command.js
+++ b/lib/refresh.command.js
@@ -23,14 +23,10 @@ module.exports = function (Aquifer) {
     }
 
     var path      = require('path'),
-        jsonFile  = require('jsonfile'),
-        jsonPath  = path.join(Aquifer.projectDir, 'aquifer.json'),
-        json      = jsonFile.readFileSync(jsonPath),
-        project   = new Aquifer.project(Aquifer.projectDir, json.name),
-        target    = options.drupalAlias ? options.drupalAlias : path.join(Aquifer.projectDir, json.paths.builds, 'work'),
-        name      = options.drupalAlias ? options.drupalAlias : project.name;
+        target    = options.drupalAlias ? options.drupalAlias : path.join(Aquifer.projectDir, Aquifer.project.config.paths.builds, 'work'),
+        name      = options.drupalAlias ? options.drupalAlias : Aquifer.project.config.name;
 
-    Aquifer.refresh(target, json.refreshCommands, function(error) {
+    Aquifer.api.refresh(target, function(error) {
       if (error) {
         Aquifer.console.log(error, 'error');
       }

--- a/lib/refresh.command.js
+++ b/lib/refresh.command.js
@@ -9,6 +9,11 @@
 module.exports = function (Aquifer) {
   'use strict';
 
+  // If the current directory doesn't contain an aquifer project, exit.
+  if (!Aquifer.initialized) {
+    return;
+  }
+
   /**
    * Define the 'refresh' command.
    */
@@ -16,12 +21,6 @@ module.exports = function (Aquifer) {
   .description('Refreshes a site against the current state of its codebase.')
   .option('-a, --drupalAlias <alias>', 'Optional alias for the target site.')
   .action(function (options) {
-    // If the current directory doesn't contain an aquifer project, exit.
-    if (!Aquifer.initialized) {
-      Aquifer.console.log('You are not currently in directory that contains an Aquifer project.', 'error');
-      return;
-    }
-
     var path      = require('path'),
         target    = options.drupalAlias ? options.drupalAlias : path.join(Aquifer.projectDir, Aquifer.project.config.paths.builds, 'work'),
         name      = options.drupalAlias ? options.drupalAlias : Aquifer.project.config.name;

--- a/src/aquifer.default.json
+++ b/src/aquifer.default.json
@@ -1,0 +1,43 @@
+{
+  "name": "false",
+  "paths": {
+    "make": "drupal.make",
+    "settings": "settings",
+    "builds": "builds/",
+    "themes": {
+      "root": "themes/",
+      "contrib": "themes/contrib",
+      "custom": "themes/custom"
+    },
+    "modules": {
+      "root": "modules",
+      "contrib": "modules/contrib",
+      "custom": "modules/custom",
+      "features": "modules/features"
+    }
+  },
+  "extensions": [],
+  "refreshCommands": [
+    [
+      "updb"
+    ],
+    [
+      "cc",
+      "all"
+    ],
+    [
+      "en",
+      "master"
+    ],
+    [
+      "master-execute",
+      "--scope=local"
+    ],
+    [
+      "fra"
+    ],
+    [
+      "rr"
+    ]
+  ]
+}

--- a/src/aquifer.default.json
+++ b/src/aquifer.default.json
@@ -1,5 +1,5 @@
 {
-  "name": "false",
+  "name": false,
   "paths": {
     "make": "drupal.make",
     "settings": "settings",


### PR DESCRIPTION
This PR cleans up the Aquifer apis in a number of ways, including the following:
- Moves all Aquifer api objects into an `Aquifer.api` property.
- Initializes an `Aquifer.api.project()` object each time Aquifer is called, and assigns it's value to `Aquifer.project()`. If the current directory contains an Aquifer project, it will load the config json and context about the project. Otherwise, `Aquifer.initialized` will be false and the `Aquifer.api.project` object will be full of defaults that can be scaffolded into a new project with `aquifer create`.
- Moved the default `aquifer.json` values into `src/aquifer.default.json` as opposed to constructing the default json configs as an object in the project api. This makes it easier to pass a full, or partial config file into `aquifer create <name> <config/file/path.json>`, as it just extends the defaults.
- Updated apis depending on the current Aquifer project to use `Aquifer.project()` instead of instantiating a new `Aquifer.api.project()` object in each command.
## Steps to demo:
- Pull this branch down into your local test repo.
- Run `Aquifer` and ensure you get the ascii art and CLI help output.
- Run each command available in aquifer, `create`, `build`, and ensure that it works, or returns valid feedback.
