### PR TITLE
Build Options

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -11,17 +11,29 @@ module.exports = function (Aquifer) {
   /**
    * Creates a build object from which operations can be initiated.
    *
-   * @param string destination path to destination folder.
+   * @param string destination Path to destination folder.
+   * @param object options configuration options for the build.
    */
-  var Build = function(destination) {
+  var Build = function(destination, options) {
     var self      = this,
+        _         = require('lodash'),
         fs        = require('fs-extra'),
+        del       = require('del'),
         path      = require('path'),
         drush     = require('drush-node'),
         promise   = require('promised-io/promise'),
         Deferred  = promise.Deferred;
 
     self.destination = destination;
+
+    self.options = {
+      symlink: true,
+      delPatterns: ['*']
+    };
+
+    if (options) {
+      _.assign(self.options, options);
+    }
 
     /**
      * Creates a Drupal root in specified directory.
@@ -62,69 +74,75 @@ module.exports = function (Aquifer) {
       };
 
       // Initialize drush and the build promise chain.
-      drush.init({log: true})
+      drush.init({log: true, cwd: self.destination})
         // Delete current build.
         .then(buildStep('Removing possible existing build...', function () {
-          fs.removeSync(self.destination);
+          del(self.options.delPatterns, {cwd: self.destination});
         }))
         // Run drush make.
         .then(buildStep('Executing drush make...', function () {
-          return drush.exec(['make', make, self.destination]);
+          return drush.exec(['make', make]);
         }))
-        // Create symlinks.
-        .then(buildStep('Creating symlinks...', function () {
-          var symlinks = [],
-              promises = [];
+        // Create symlinks or copy.
+        .then(buildStep(this.options.symlink ? 'Creating symlinks...' : 'Copying files and directories...', function () {
+          var links     = [],
+              promises  = [];
 
-          // Add custom modules symlink.
-          symlinks.push({
+          // Add custom modules link.
+          links.push({
             src: Aquifer.project.absolutePaths.modules.custom,
             dest: path.join(self.destination, 'sites/all/modules/custom'),
             type: 'dir'
           });
 
-          // Add features symlink.
-          symlinks.push({
+          // Add features link.
+          links.push({
             src: Aquifer.project.absolutePaths.modules.features,
             dest: path.join(self.destination, 'sites/all/modules/features'),
             type: 'dir'
           });
 
-          // Add custom themes symlink.
-          symlinks.push({
+          // Add custom themes link.
+          links.push({
             src: Aquifer.project.absolutePaths.themes.custom,
             dest: path.join(self.destination, 'sites/all/themes/custom'),
             type: 'dir'
           });
 
-          // Add settings files symlinks.
+          // Add settings files links.
           fs.readdirSync(Aquifer.project.absolutePaths.settings)
             .filter(function (file) {
               return file.indexOf('.') !== 0;
             })
             .forEach(function (file) {
-              symlinks.push({
+              links.push({
                 src: path.join(Aquifer.project.absolutePaths.settings, file),
                 dest: path.join(self.destination, 'sites/default', file),
                 type: 'file'
               });
             });
 
-          // Create a promise for each symlink creation.
-          promises = symlinks.map(function (link) {
-            var def = new Deferred();
+          // Create a promise for each link creation.
+          promises = links.map(function (link) {
+            var def           = new Deferred(),
+                linkCallback  = function (err) {
+                  if (err) {
+                    return def.reject(err);
+                  }
+                  def.resolve();
+                };
 
-            fs.symlink(link.src, link.dest, link.type, function (err) {
-              if (err) {
-                return def.reject(err);
-              }
-              def.resolve();
-            });
+            if (self.options.symlink) {
+              fs.symlink(link.src, link.dest, link.type, linkCallback);
+            }
+            else {
+              fs.copy(link.src, link.dest, linkCallback);
+            }
 
             return def.promise;
           });
 
-          // Return a promise for the completed creation of all symlinks.
+          // Return a promise for the completed creation of all links.
           return promise.all(promises);
         }))
         // Complete the build promise chain.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "commander": "^2.7.1",
+    "del": "^1.2.1",
     "drush-node": "chasingmaxwell/drush-node",
     "fs-extra": "^0.18.0",
     "jsonfile": "^2.0.0",


### PR DESCRIPTION
This PR does the following:
1. Adds the option to make copies instead of symlinks in the build.
2. Adds the ability to specify the deletion patterns when clearing an existing repository. This was important for aquifer-git because we were building into a git repository and needed to preserve the `.git` directory.
3. Instead of specifying the destination path in drush make we use cwd to run drush make from the destination directory. This is necessary when building from a directory that already exists (necessary for aquifer-git since we were building into a git repository).
## To Review:
1. Run `aquifer build` on an existing project and make sure the site is built as normal with symlinks for custom modules, themes, features, etc.
2. There isn't currently a way to specify these other options from the command line, but you could fiddle with the code to pass options (`symlink` and `delPatterns`) to `Build()` and see that they function the way you would expect.

You can check out [aquifer-git](https://github.com/aquifer/aquifer-git) for an example of how these options will be used. Currently aquifer-git will only work with the extension system PR AND this PR merged in.
