### PR TITLE
Make sure the full destination path exists before building against it

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -73,6 +73,11 @@ module.exports = function (Aquifer) {
         };
       };
 
+      // If the destination does not exist (was deleted or first build) create it.
+      if (!fs.existsSync(self.destination)) {
+        fs.mkdirSync(self.destination);
+      }
+
       // Initialize drush and the build promise chain.
       drush.init({log: true, cwd: self.destination})
         // Delete current build.


### PR DESCRIPTION
The build system was broken. When a user specifies a root directory that isn't created (aka initial build) it will fail because it cannot initialize a child process (like drush) in a non-existent directory.
## Steps to test
- Checkout this branch
- Run `aquifer create test && cd test && aquifer build`
- Ensure aquifer builds with no EONET errors.
