### PR TITLE
Remove multiple builds

### DIFF
--- a/lib/build.command.js
+++ b/lib/build.command.js
@@ -28,7 +28,7 @@ module.exports = function (Aquifer) {
 
     // load json settings file.
     json = jsonFile.readFileSync(jsonPath);
-    directory = path.join(Aquifer.projectDir, json.paths.builds, json.paths.root);
+    directory = path.join(Aquifer.projectDir, json.paths.build);
     make = path.join(Aquifer.projectDir, json.paths.make);
     build = new Aquifer.api.build(directory);
 

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -60,7 +60,7 @@ module.exports = function (Aquifer) {
       json: jsonPath,
       make: path.join(self.directory, self.config.paths.make),
       settings: path.join(self.directory, self.config.paths.settings),
-      builds: path.join(self.directory, self.config.paths.builds),
+      build: path.join(self.directory, self.config.paths.build),
       themes: {
         root: path.join(self.directory, self.config.paths.themes.root),
         contrib: path.join(self.directory, self.config.paths.themes.contrib),
@@ -89,7 +89,7 @@ module.exports = function (Aquifer) {
 
       // Create root, modules, builds, and themes folders.
       fs.mkdirSync(self.directory);
-      fs.mkdirSync(self.absolutePaths.builds);
+      fs.mkdirSync(self.absolutePaths.build);
       fs.mkdirSync(self.absolutePaths.settings);
       fs.mkdirSync(self.absolutePaths.themes.root);
       fs.mkdirSync(self.absolutePaths.themes.custom);
@@ -103,7 +103,7 @@ module.exports = function (Aquifer) {
       touch.sync(path.join(self.absolutePaths.modules.features, '.gitkeep'));
       touch.sync(path.join(self.absolutePaths.themes.root, '.gitkeep'));
       touch.sync(path.join(self.absolutePaths.themes.custom, '.gitkeep'));
-      touch.sync(path.join(self.absolutePaths.builds, '.gitkeep'));
+      touch.sync(path.join(self.absolutePaths.build, '.gitkeep'));
       touch.sync(path.join(self.absolutePaths.settings, '.gitkeep'));
 
       // Copy over src files.

--- a/src/aquifer.default.json
+++ b/src/aquifer.default.json
@@ -3,8 +3,7 @@
   "paths": {
     "make": "drupal.make",
     "settings": "settings",
-    "builds": "builds",
-    "root": "work",
+    "build": "build",
     "themes": {
       "root": "themes",
       "contrib": "themes/contrib",


### PR DESCRIPTION
This PR removes the `/builds/*` subfolder. At this time, there is no reason to support multiple build directories within the project. If we want to support external builds, that should be done by adding an option to the `aquifer build` command or by creating an extension that does this.
## Steps to test
- Checkout this branch.
- Create a new project: `aquifer create test`
- In that new project's root, run `aquifer build`
- Ensure that a `build` directory exists and contains a drupal site root
- Run `aquifer build` again and ensure that it correctly re-builds.
