### PR TITLE
Specify a subversion for drupal core in drupal.make

### DIFF
--- a/src/drupal.make
+++ b/src/drupal.make
@@ -10,7 +10,7 @@ api = 2
 
 ; Core project.
 ; ------------
-projects[drupal][version] = 7.x
+projects[drupal][version] = 7.39
 
 
 ; Set contrib modules dir.


### PR DESCRIPTION
This PR specifies a subversion for Drupal core by default. This is done for the following reasons:
- Aquifer project's should never update the Drupal build version automatically. Aquifer/drush make makes it easy to update the Drupal core version, but that should be done explicitly and the site should be tested when a core update is done.
- Drush make locking doesn't work with a "default to latest" version pattern for Drupal core, probably for the reason outlined above.
## Steps to test
- Checkout this branch.
- Create a new project: `aquifer create test`
- In that projects root, run `aquifer build` and ensure that the site builds using the correct version of Drupal core.
- Run `aquifer build` again and ensure that it builds correctly once more.
