### PR TITLE
aquifer.local.json overrides aquifer.json

### DIFF
--- a/lib/build.command.js
+++ b/lib/build.command.js
@@ -27,7 +27,7 @@ module.exports = function (Aquifer) {
         lockFile  = settings.paths.lock !== false ? path.join(Aquifer.projectDir, settings.paths.lock) : false,
         make      = options.make === true,
         refreshLock = lockFile !== false && options.refreshLock === true,
-        directory = path.join(Aquifer.projectDir, settings.paths.build),
+        directory = settings.paths.build,
         build     = new Aquifer.api.build(directory);
 
     build.create(make, refreshLock, makeFile, lockFile, function(error) {

--- a/lib/build.command.js
+++ b/lib/build.command.js
@@ -22,9 +22,7 @@ module.exports = function (Aquifer) {
   .option('-r, --refresh-lock', 'Regenerate the lock file from the make file.')
   .action(function (options) {
     var path      = require('path'),
-        jsonFile  = require('jsonfile'),
-        jsonPath  = path.join(Aquifer.projectDir, 'aquifer.json'),
-        settings  = jsonFile.readFileSync(jsonPath),
+        settings  = Aquifer.project.config,
         makeFile  = path.join(Aquifer.projectDir, settings.paths.make),
         lockFile  = settings.paths.lock !== false ? path.join(Aquifer.projectDir, settings.paths.lock) : false,
         make      = options.make === true,
@@ -37,7 +35,7 @@ module.exports = function (Aquifer) {
         Aquifer.console.log(error, 'error');
       }
       else {
-        Aquifer.console.log(Aquifer.project.config.name + ' build created successfully!', 'success');
+        Aquifer.console.log(settings.name + ' build created successfully!', 'success');
       }
     });
   });

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -18,17 +18,18 @@ module.exports = function (Aquifer) {
    * @returns {object} instance of the Project object.
    */
   var Project = function(directory, name, configJsonPath) {
-    var self      = this,
-        _         = require('lodash'),
-        fs        = require('fs-extra'),
-        path      = require('path'),
-        touch     = require('touch'),
-        jsonFile  = require('jsonfile'),
-        jsonPath  = path.join(directory, 'aquifer.json'),
-        srcDir    = path.join(path.dirname(fs.realpathSync(__filename)), '../src');
+    var self          = this,
+        _             = require('lodash'),
+        fs            = require('fs-extra'),
+        path          = require('path'),
+        touch         = require('touch'),
+        jsonFile      = require('jsonfile'),
+        jsonPath      = path.join(directory, 'aquifer.json'),
+        localJsonPath = path.join(directory, 'aquifer.local.json'),
+        srcDir        = path.join(path.dirname(fs.realpathSync(__filename)), '../src');
 
     // Set directory, name, and status. Directory is required!
-    self.directory = directory ||  Aquifer.cwd;
+    self.directory = directory || Aquifer.cwd;
 
     // Decide whether or not this is initialized already.
     self.initialized = fs.existsSync(self.directory) || fs.existsSync(jsonPath) ? true : false;
@@ -36,6 +37,11 @@ module.exports = function (Aquifer) {
     // If this project is initialized, load the JSON path.
     if (self.initialized) {
       self.config = jsonFile.readFileSync(jsonPath);
+
+      // Extend config with aquifer.local.json.
+      if (fs.existsSync(localJsonPath)) {
+        _.merge(self.config, jsonFile.readFileSync(localJsonPath));
+      }
     }
     // If this is a new (uninitialized) project, load the default json.
     else {
@@ -45,7 +51,7 @@ module.exports = function (Aquifer) {
     // If a config json path was passed in, extend the default.
     if (configJsonPath) {
       var configJson = jsonFile.readFileSync(configJsonPath);
-      _.extend(self.config, configJson);
+      _.merge(self.config, configJson);
     }
 
     // Set name, default to basename of directory.

--- a/lib/refresh.command.js
+++ b/lib/refresh.command.js
@@ -22,7 +22,7 @@ module.exports = function (Aquifer) {
   .option('-a, --drupalAlias <alias>', 'Optional alias for the target site.')
   .action(function (options) {
     var path      = require('path'),
-        target    = options.drupalAlias ? options.drupalAlias : path.join(Aquifer.projectDir, Aquifer.project.config.paths.build),
+        target    = options.drupalAlias ? options.drupalAlias : Aquifer.project.config.paths.build,
         name      = options.drupalAlias ? options.drupalAlias : Aquifer.project.config.name;
 
     Aquifer.api.refresh(target, function(error) {


### PR DESCRIPTION
This PR does the following:
1. Ensures that only the project API gets config from json, the rest should get it from `Aquifer.project.config`.
2. Uses _.merge instead of _.extend to override configuration so we override recursively instead of just the first level.
3. Overrides the aquifer.json configuration with aquifer.local.json if it exists.
4. Allows builds outside the project root.
## To Review:
1. Run `aquifer build` and make sure everything is normal when the build directory is inside the project root. (by default it is in `./build`)
2. Add an `aquifer.local.json` file with the following contents:
   
   ``` json
   {
     "paths": {
       "build": "/some/path/outside/your/project/root"
     }
   }
   ```
3. Run `aquifer build` and see that it builds into the external directory.
4. Ensure that `aquifer refresh` runs without errors.
