### PR TITLE
Fix lock refresh logic

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -44,7 +44,7 @@ module.exports = function (Aquifer) {
      * @param {boolean} refreshLock If true, forces a build from the make file
      *   and regenerates the lock file.
      * @param {string} makeFile Absolute path to the make file.
-   *   @param {string|boolean} lockFile Absolute path to the lock file or false
+     * @param {string|boolean} lockFile Absolute path to the lock file or false
      *   if lock file is set to false in aquifer.json.
      * @param {function} callback Called when process finishes executing or
      *   errors out.
@@ -126,7 +126,7 @@ module.exports = function (Aquifer) {
           }
 
           switch (true) {
-            case (refreshLock && lockFile):
+            case (refreshLock && lockFile !== false && lockExists):
               // Build from make file, and generate lock file.
               return drush.exec(['make', makeFile, '--lock=' + lockFile]);
 


### PR DESCRIPTION
Lock refresh is broken. This should fix it.

`aquifer build`

If no lock file, build from make and generate lock.
If lock file exists, builkd from lock.

`aquifer build -m`

Build from make, do not regenerate lock.

`aquifer build -r`

Build from make, regenerate lock.
