### PR TITLE
Semantic versioning tools

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ gulp.task('lint', function () {
  * @task watch
  * Runs lint tasks when files are changed.
  */
-gulp.task('watch', function() {
+gulp.task('watch', function () {
   gulp.watch(jsFilePatterns, ['lint']);
 });
 
@@ -40,7 +40,7 @@ gulp.task('watch', function() {
  * @task bump-prerelease
  *   Increment Aquifer's prerelease version by 1.
  */
-gulp.task('bump-prerelease', function(){
+gulp.task('bump-prerelease', function () {
   gulp.src('./package.json')
   .pipe(bump({type: 'prerelease'}))
   .pipe(gulp.dest('./'));
@@ -50,7 +50,7 @@ gulp.task('bump-prerelease', function(){
  * @task bump-patch
  *   Increment Aquifer's patch version by 1.
  */
-gulp.task('bump-patch', function(){
+gulp.task('bump-patch', function () {
   gulp.src('./package.json')
   .pipe(bump({type: 'patch'}))
   .pipe(gulp.dest('./'));
@@ -60,7 +60,7 @@ gulp.task('bump-patch', function(){
  * @task bump-minor
  *   Increment Aquifer's minor version by 1.
  */
-gulp.task('bump-minor', function(){
+gulp.task('bump-minor', function () {
   gulp.src('./package.json')
   .pipe(bump({type: 'minor'}))
   .pipe(gulp.dest('./'));
@@ -70,7 +70,7 @@ gulp.task('bump-minor', function(){
  * @task bump-major
  *   Increment Aquifer's major version by 1.
  */
-gulp.task('bump-major', function(){
+gulp.task('bump-major', function () {
   gulp.src('./package.json')
   .pipe(bump({type: 'major'}))
   .pipe(gulp.dest('./'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@
 var gulp            = require('gulp'),
     eslint          = require('gulp-eslint'),
     jscs            = require('gulp-jscs'),
+    bump            = require('gulp-bump'),
     jsFilePatterns  = [
       'index.js',
       'lib/*.js',
@@ -33,4 +34,44 @@ gulp.task('lint', function () {
  */
 gulp.task('watch', function() {
   gulp.watch(jsFilePatterns, ['lint']);
+});
+
+/**
+ * @task bump-prerelease
+ *   Increment Aquifer's prerelease version by 1.
+ */
+gulp.task('bump-prerelease', function(){
+  gulp.src('./package.json')
+  .pipe(bump({type: 'prerelease'}))
+  .pipe(gulp.dest('./'));
+});
+
+/**
+ * @task bump-patch
+ *   Increment Aquifer's patch version by 1.
+ */
+gulp.task('bump-patch', function(){
+  gulp.src('./package.json')
+  .pipe(bump({type: 'patch'}))
+  .pipe(gulp.dest('./'));
+});
+
+/**
+ * @task bump-minor
+ *   Increment Aquifer's minor version by 1.
+ */
+gulp.task('bump-minor', function(){
+  gulp.src('./package.json')
+  .pipe(bump({type: 'minor'}))
+  .pipe(gulp.dest('./'));
+});
+
+/**
+ * @task bump-major
+ *   Increment Aquifer's major version by 1.
+ */
+gulp.task('bump-major', function(){
+  gulp.src('./package.json')
+  .pipe(bump({type: 'major'}))
+  .pipe(gulp.dest('./'));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,6 +26,7 @@ gulp.task('lint', function () {
   .pipe(eslint.format())
   .pipe(jscs());
 });
+
 /**
  * @task watch
  * Runs lint tasks when files are changed.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "gulp": "^3.8.11",
+    "gulp-bump": "^1.0.0",
     "gulp-eslint": "^1.0.0",
     "gulp-jscs": "^1.5.1",
     "gulp-jshint": "^1.10.0"


### PR DESCRIPTION
This PR introduces tools that standardizes the process for incrementing prerelease, patch, minor, and major versions of this project. 
## Steps to test
- Checkout this branch
- In the project directory, run the following command:

```
gulp bump-major && gulp bump-minor && gulp bump-patch && gulp bump-prerelease
```
- Open the `package.json` file and ensure that the version is now set to `1.1.2-0`.
- Note that the current version in `package.json` is `0.0.1`, and that incrementing the major, minor, patch, and prerelease versions all at once should bump the version to `1.1.2-0`.
