### PR TITLE
Relative build symlinks

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -156,29 +156,29 @@ module.exports = function (Aquifer) {
 
           // Add custom modules link.
           links.push({
-            src: Aquifer.project.absolutePaths.modules.custom,
-            dest: path.join(self.destination, 'sites/all/modules/custom'),
+            src: Aquifer.project.config.paths.modules.custom,
+            dest: 'sites/all/modules/custom',
             type: 'dir'
           });
 
           // Add features link.
           links.push({
-            src: Aquifer.project.absolutePaths.modules.features,
-            dest: path.join(self.destination, 'sites/all/modules/features'),
+            src: Aquifer.project.config.paths.modules.features,
+            dest: 'sites/all/modules/features',
             type: 'dir'
           });
 
           // Add custom themes link.
           links.push({
-            src: Aquifer.project.absolutePaths.themes.custom,
-            dest: path.join(self.destination, 'sites/all/themes/custom'),
+            src: Aquifer.project.config.paths.themes.custom,
+            dest: 'sites/all/themes/custom',
             type: 'dir'
           });
 
           // Add files link.
           links.push({
-            src: Aquifer.project.absolutePaths.files.root,
-            dest: path.join(self.destination, 'sites/default/files'),
+            src: Aquifer.project.config.paths.files.root,
+            dest: 'sites/default/files',
             type: 'dir'
           });
 
@@ -189,8 +189,8 @@ module.exports = function (Aquifer) {
             })
             .forEach(function (file) {
               links.push({
-                src: path.join(Aquifer.project.absolutePaths.settings, file),
-                dest: path.join(self.destination, 'sites/default', file),
+                src: path.join(Aquifer.project.config.paths.settings, file),
+                dest: path.join('sites/default', file),
                 type: 'file'
               });
             });
@@ -205,8 +205,8 @@ module.exports = function (Aquifer) {
               fs.unlinkSync(path.join(self.destination, file));
 
               links.push({
-                src: path.join(Aquifer.project.absolutePaths.root, file),
-                dest: path.join(self.destination, file),
+                src: path.join(Aquifer.project.config.paths.root, file),
+                dest: file,
                 type: 'file'
               });
             });
@@ -222,7 +222,15 @@ module.exports = function (Aquifer) {
                 };
 
             if (self.options.symlink) {
-              fs.symlink(link.src, link.dest, link.type, linkCallback);
+              // Make src and dest absolute paths.
+              link.dest = path.join(self.destination, link.dest);
+              link.src = path.join(self.destination, link.src);
+
+              // Change current directory to the destination base path (minus last part of path).
+              process.chdir(path.dirname(link.dest));
+
+              // Symlink the relative path of the src from the destination into the basename of the path.
+              fs.symlink(path.relative(link.dest, link.src), path.basename(link.dest), link.type, linkCallback);
             }
             else {
               fs.copy(link.src, link.dest, linkCallback);

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -26,7 +26,7 @@ module.exports = function (Aquifer) {
         promise   = require('promised-io/promise'),
         Deferred  = promise.Deferred;
 
-    self.destination = destination;
+    self.destination = path.join(Aquifer.project.directory, destination);
 
     self.options = {
       symlink: true,


### PR DESCRIPTION
This PR changes symlinking behaviors within the build system so that all symlinks are created with relative source paths. This makes it possible to run the built site in a vm over a shared filesystem.
## Steps to demo
- Checkout this branch.
- Create an aquifer project.
- Run `aquifer build` within the project's root.
- Ensure that custom modules, themes, settings files, and root files are synced with relative paths.

This PR also fixes an issue with the directory in which the build system chose to place builds. Previously, the build system used a relative path to choose be build directory. This means that the build directory would be constructed as a subfolder of your cwd at time of running the build command. This has been resolved, so you can now run the build command in any subdirectory of an aquifer project, and the build system will build into the correct build folder (as specified in aquifer.json).
