### PR TITLE
Fix copying in build API

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -26,8 +26,15 @@ module.exports = function (Aquifer) {
         promise   = require('promised-io/promise'),
         Deferred  = promise.Deferred;
 
+    // Set class properties.
     self.destination = destination;
 
+    // Intelligently transform destination into an absolute path.
+    if (path.resolve(self.destination) !== self.destination) {
+      self.destination = path.join(Aquifer.project.directory, self.destination);
+    }
+
+    // Set default options.
     self.options = {
       symlink: true,
       delPatterns: ['*']
@@ -221,21 +228,20 @@ module.exports = function (Aquifer) {
                   def.resolve();
                 };
 
-            // Make src and dest absolute paths.
+            // Make src and dest paths absolute.
             link.dest = path.join(self.destination, link.dest);
+            link.src = path.join(Aquifer.project.directory, link.src);
 
             // If symlinking is turned on, symlink custom files. Else, copy.
             if (self.options.symlink) {
-              link.src = path.join(self.destination, link.src);
-
               // Change current directory to the destination base path (minus last part of path).
-              process.chdir(path.dirname(link.dest));
+              var destBase = path.dirname(link.dest);
+              process.chdir(destBase);
 
               // Symlink the relative path of the src from the destination into the basename of the path.
-              fs.symlink(path.relative(link.dest, link.src), path.basename(link.dest), link.type, linkCallback);
+              fs.symlink(path.relative(destBase, link.src), path.basename(link.dest), link.type, linkCallback);
             }
             else {
-              link.src = path.join(Aquifer.project.directory, link.src);
               fs.copy(link.src, link.dest, linkCallback);
             }
 

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -221,9 +221,11 @@ module.exports = function (Aquifer) {
                   def.resolve();
                 };
 
+            // Make src and dest absolute paths.
+            link.dest = path.join(self.destination, link.dest);
+
+            // If symlinking is turned on, symlink custom files. Else, copy.
             if (self.options.symlink) {
-              // Make src and dest absolute paths.
-              link.dest = path.join(self.destination, link.dest);
               link.src = path.join(self.destination, link.src);
 
               // Change current directory to the destination base path (minus last part of path).
@@ -233,6 +235,7 @@ module.exports = function (Aquifer) {
               fs.symlink(path.relative(link.dest, link.src), path.basename(link.dest), link.type, linkCallback);
             }
             else {
+              link.src = path.join(Aquifer.project.directory, link.src);
               fs.copy(link.src, link.dest, linkCallback);
             }
 

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -26,7 +26,7 @@ module.exports = function (Aquifer) {
         promise   = require('promised-io/promise'),
         Deferred  = promise.Deferred;
 
-    self.destination = path.join(Aquifer.project.directory, destination);
+    self.destination = destination;
 
     self.options = {
       symlink: true,

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -82,6 +82,11 @@ module.exports = function (Aquifer) {
       }
     };
 
+    // Make sure build absolute path is correct.
+    if (path.resolve(self.config.paths.build) === self.config.paths.build) {
+      self.absolutePaths.build = self.config.paths.build;
+    }
+
     /**
      * Creates and scaffolds this project as defined.
      *


### PR DESCRIPTION
This PR fixes issues with custom file copying in the build API for this PR: https://github.com/aquifer/aquifer-git/pull/2

This PR also makes it possible to build outside of the project root with correct relative symlinked custom files.
## Steps to test
- Checkout this branch.
- Create an aquifer project.
- In the project root, run `aquifer build`
- Ensure that the build completes correctly, and that the custom files are linked correctly.
- Edit the project's aquifer.json file, and change the build path to an absolute URL.
- Run `aquifer build` once more.
- Ensure that the absolute build path is created correctly, and that the custom files are linked correctly.
