### PR TITLE
Make sure .aquifer dir exists before installing to it

### DIFF
--- a/lib/extension.api.js
+++ b/lib/extension.api.js
@@ -113,12 +113,19 @@ module.exports = function (Aquifer) {
      */
     self.download = function (callback) {
       // Set command to link if local.
-      var command = self.isLocal ? 'link' : 'install';
+      var command = self.isLocal ? 'link' : 'install',
+          vendor  = path.join(Aquifer.project.directory, '.aquifer');
 
       // Callback defaults to empty.
       callback = callback || function () {};
 
-      exec('cd ' + path.join(Aquifer.project.directory, '.aquifer') + ' && npm ' + command + ' --save ' + self.source, function(err, stdout, stderr) {
+      // If the .aquifer directory does not exist yet, create it.
+      if (!fs.existsSync(vendor)) {
+        fs.mkdirSync(vendor);
+      }
+
+      // Download the extensions.
+      exec('cd ' + vendor + ' && npm ' + command + ' --save ' + self.source, function(err, stdout, stderr) {
         if (err) {
           callback('Could not download ' + self.name + ': ' + err);
           return false;

--- a/lib/extension.api.js
+++ b/lib/extension.api.js
@@ -20,7 +20,7 @@ module.exports = function (Aquifer) {
     var self        = this,
         exec        = require('child_process').exec,
         path        = require('path'),
-        fs          = require('fs');
+        fs          = require('fs-extra');
 
     /**
      * Determines whether or not a path exists.
@@ -121,7 +121,12 @@ module.exports = function (Aquifer) {
 
       // If the .aquifer directory does not exist yet, create it.
       if (!fs.existsSync(vendor)) {
+        // Make the directory.
         fs.mkdirSync(vendor);
+
+        // Copy src/package.json into .aquifer/package.json.
+        var srcDir = path.join(path.dirname(fs.realpathSync(__filename)), '../src');
+        fs.copySync(path.join(srcDir, 'package.json'), path.join(vendor, 'package.json'));
       }
 
       // Download the extensions.


### PR DESCRIPTION
This PR adds a small line of code that ensures the existence of the .aquifer dir before attempting to install extensions into it.

This PR fixes https://github.com/aquifer/aquifer/issues/53
## Steps to demo
- Checkout this branch
- Create an aquifer project
- Add an extension
- Remove the .aquifer directory
- Run `aquifer extensions-load`
- Ensure that extensions are loaded correctly, and that a new `.aquifer` directory is created.
