### PR TITLE
Turn off locking by default

### DIFF
--- a/src/aquifer.default.json
+++ b/src/aquifer.default.json
@@ -2,7 +2,7 @@
   "name": false,
   "paths": {
     "make": "drupal.make",
-    "lock": "drupal.make.lock",
+    "lock": false,
     "settings": "settings",
     "build": "build",
     "root": "root",


### PR DESCRIPTION
This PR introduces a change to the default `aquifer.json` file that turns Drush make locking off by default. Drush make locking has compatibility issues between Drush versions, and has a number of bugs that make it difficult to use. Per some discussions, we decided it would be best to make it opt-in.
# Steps to test
- Checkout this branch
- Create an aquifer project: `aquifer create test`
- Build the project: `aquifer build`
- Ensure that no lock file is generated.
