### PR TITLE
OSX Filesystem permissions fix

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -161,7 +161,7 @@ module.exports = function (Aquifer) {
         }))
         // Set sites/default permissions correctly.
         .then(buildStep('Setting permissions on build files.', function () {
-          fs.chmodSync(path.join(Aquifer.project.directory, 'files'), '755');
+          fs.chmodSync(path.join(Aquifer.project.absolutePaths.build, 'sites/default'), '755');
         }))
         // Create symlinks or copy.
         .then(buildStep(this.options.symlink ? 'Creating symlinks...' : 'Copying files and directories...', function () {

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -159,6 +159,10 @@ module.exports = function (Aquifer) {
               }
           }
         }))
+        // Set sites/default permissions correctly.
+        .then(buildStep('Setting permissions on build files.', function () {
+          fs.access(path.join(Aquifer.project.directory, 'files'), fs.W_OK, function () {});
+        }))
         // Create symlinks or copy.
         .then(buildStep(this.options.symlink ? 'Creating symlinks...' : 'Copying files and directories...', function () {
           var links     = [],
@@ -261,10 +265,6 @@ module.exports = function (Aquifer) {
 
           // Return a promise for the completed creation of all links.
           return promise.all(promises);
-        }))
-        // Set sites/default permissions correctly.
-        .then(buildStep('Setting permissions on build files.', function () {
-          fs.access(path.join(Aquifer.project.absolutePaths.build, 'sites/default'), fs.W_OK, function () {});
         }))
         // Complete the build promise chain.
         .then(function (res) {

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -161,7 +161,7 @@ module.exports = function (Aquifer) {
         }))
         // Set sites/default permissions correctly.
         .then(buildStep('Setting permissions on build files.', function () {
-          fs.access(path.join(Aquifer.project.directory, 'files'), fs.W_OK, function () {});
+          fs.chmodSync(path.join(Aquifer.project.directory, 'files'), '755');
         }))
         // Create symlinks or copy.
         .then(buildStep(this.options.symlink ? 'Creating symlinks...' : 'Copying files and directories...', function () {

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -114,6 +114,10 @@ module.exports = function (Aquifer) {
 
       // Initialize drush and the build promise chain.
       drush.init({log: true, cwd: self.destination})
+        // Set sites/default permissions correctly.
+        .then(buildStep('Setting permissions on build files.', function () {
+          fs.chmodSync(path.join(Aquifer.project.absolutePaths.build, 'sites/default'), '755');
+        }))
         // Delete current build.
         .then(buildStep('Removing possible existing build...', function () {
           del(self.options.delPatterns, {cwd: self.destination});
@@ -158,10 +162,6 @@ module.exports = function (Aquifer) {
                 return drush.exec(['make', makeFile, '--lock=' + lockFile]);
               }
           }
-        }))
-        // Set sites/default permissions correctly.
-        .then(buildStep('Setting permissions on build files.', function () {
-          fs.chmodSync(path.join(Aquifer.project.absolutePaths.build, 'sites/default'), '755');
         }))
         // Create symlinks or copy.
         .then(buildStep(this.options.symlink ? 'Creating symlinks...' : 'Copying files and directories...', function () {

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -59,6 +59,9 @@ module.exports = function (Aquifer) {
      * @returns {boolean} true if the build is created, false if it fails.
      */
     self.create = function (make, refreshLock, makeFile, lockFile, callback) {
+      // Callback falls back to an empty function.
+      callback = callback || function () {};
+
       // If project isn't initialized (doesn't exist) then exit.
       if (!Aquifer.initialized) {
         callback('Cannot build a project that hasn\'t been initialized.');
@@ -258,6 +261,10 @@ module.exports = function (Aquifer) {
 
           // Return a promise for the completed creation of all links.
           return promise.all(promises);
+        }))
+        // Set sites/default permissions correctly.
+        .then(buildStep('Setting permissions on build files.', function () {
+          fs.access(path.join(Aquifer.project.absolutePaths.build, 'sites/default'), fs.W_OK, function () {});
         }))
         // Complete the build promise chain.
         .then(function (res) {


### PR DESCRIPTION
This PR fixes a problem where sites/default had incorrect permissions on OSX when trying to rebuild.
