### PR TITLE
Ensure the existence of /sites/default before changing perms

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -114,9 +114,12 @@ module.exports = function (Aquifer) {
 
       // Initialize drush and the build promise chain.
       drush.init({log: true, cwd: self.destination})
-        // Set sites/default permissions correctly.
+        // Set sites/default permissions for OSX.
         .then(buildStep('Setting permissions on build files.', function () {
-          fs.chmodSync(path.join(Aquifer.project.absolutePaths.build, 'sites/default'), '755');
+          var defaultDir = path.join(Aquifer.project.absolutePaths.build, 'sites/default');
+          if (fs.existsSync(defaultDir)) {
+            fs.chmodSync(defaultDir, '755');
+          }
         }))
         // Delete current build.
         .then(buildStep('Removing possible existing build...', function () {


### PR DESCRIPTION
This PR introduces a couple lines that ensure the existence of `/sites/default` before attempting to change it's permission set.
## Steps to test
- Checkout this branch
- Create an aquifer project: `aquifer create test`
- Build the aquifer project: `aquifer build`
- Ensure that the build completes without throwing an error about trying to change permissions on a file that doesn't exist.
