### PR TITLE
Ensure directories exist before trying to chdir into them

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -106,8 +106,7 @@ module.exports = function (Aquifer) {
         };
       };
 
-      // If the destination does not exist (was deleted or first build) create
-      // it.
+      // If the destination does not exist (was deleted or first build) create.
       if (!fs.existsSync(self.destination)) {
         fs.mkdirSync(self.destination);
       }
@@ -252,8 +251,14 @@ module.exports = function (Aquifer) {
 
             // If symlinking is turned on, symlink custom files. Else, copy.
             if (self.options.symlink) {
-              // Change current directory to the destination base path (minus last part of path).
               var destBase = path.dirname(link.dest);
+
+              // Make sure the destination base path exists.
+              if (!fs.existsSync(destBase)) {
+                fs.mkdirSync(destBase);
+              }
+
+              // Change current directory to the destination base path (minus last part of path).
               process.chdir(destBase);
 
               // Symlink the relative path of the src from the destination into the basename of the path.


### PR DESCRIPTION
This PR solves a problem that is introduced when using Drush 8. It ensure that, the portion of the build API that generates relative symlinks, that the base directory of the symlink exists before trying to travel to that dir and create the symlink.
## Steps to test
- Checkout this branch.
- Create a project: `aquifer create test`
- In the project root, build the project: `aquifer build`
- Ensure that no "missing dir" errors are thrown.
