### PR TITLE
Add note about drush version compatibility to READEME

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Aquifer is an npm module, installing it is relatively painless:
 
 * Ensure that node.js and npm are installed. We recommend using [nvm](https://github.com/creationix/nvm) to do this.
 * In your command line, run: `npm install -g aquifer`
+* NOTE: Currently, Aquifer is only compatible with [Drush 7.x and 6.x](http://www.drush.org/en/master/install/).
 
 Aquifer should now be installed!
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Aquifer is a command line interface that makes it easy to scaffold, build, test,
 Aquifer is an npm module, installing it is relatively painless:
 
 * Ensure that node.js and npm are installed. We recommend using [nvm](https://github.com/creationix/nvm) to do this.
+* Install [Drush](http://www.drush.org/en/master/install/). Aquifer is compatible with Drush 7.x and 6.x.
 * In your command line, run: `npm install -g aquifer`
-* NOTE: Currently, Aquifer is only compatible with [Drush 7.x and 6.x](http://www.drush.org/en/master/install/).
 
 Aquifer should now be installed!
 


### PR DESCRIPTION
Drush 8.x seems to have issues with `drush make` which was causing `aquifer build` to fail. A note was added to the README about compatibility.
