### PR TITLE
#85 - Provide support for custom drush folders.

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -181,6 +181,15 @@ module.exports = function (Aquifer) {
             });
           }
 
+          // Drush.
+          if (Aquifer.project.config.paths.drush) {
+            links.push({
+              src: Aquifer.project.config.paths.drush,
+              dest: 'sites/all/drush',
+              type: 'dir'
+            });
+          }
+
           // Add module links.
           Object.keys(Aquifer.project.config.paths.modules).forEach(function(key) {
             if (key !== 'root' && key !== 'contrib') {

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -65,6 +65,7 @@ module.exports = function (Aquifer) {
       make: path.join(self.directory, self.config.paths.make),
       settings: path.join(self.directory, self.config.paths.settings),
       root: path.join(self.directory, self.config.paths.root),
+      drush: path.join(self.directory, self.config.paths.drush),
       build: path.join(self.directory, self.config.paths.build),
       themes: {
         root: path.join(self.directory, self.config.paths.themes.root),
@@ -105,6 +106,7 @@ module.exports = function (Aquifer) {
       fs.mkdirSync(self.absolutePaths.build);
       fs.mkdirSync(self.absolutePaths.settings);
       fs.mkdirSync(self.absolutePaths.root);
+      fs.mkdirSync(self.absolutePaths.drush);
       fs.mkdirSync(self.absolutePaths.themes.root);
       fs.mkdirSync(self.absolutePaths.themes.custom);
       fs.mkdirSync(self.absolutePaths.modules.root);
@@ -128,6 +130,7 @@ module.exports = function (Aquifer) {
       fs.copySync(path.join(srcDir, 'default.secret.settings.php'), path.join(self.absolutePaths.settings, 'secret.settings.php'));
       fs.copySync(path.join(srcDir, 'default.local.settings.php'), path.join(self.absolutePaths.settings, 'local.settings.php'));
       fs.copySync(path.join(srcDir, 'drupal.make.yml'), self.absolutePaths.make);
+      fs.copySync(path.join(srcDir, 'drushrc.php'), path.join(self.absolutePaths.drush, 'drushrc.php'));
       fs.copySync(path.join(srcDir, 'editorconfig'), path.join(self.directory, '.editorconfig'));
       fs.copySync(path.join(srcDir, 'gitignore'), path.join(self.directory, '.gitignore'));
       fs.copySync(path.join(srcDir, 'package.json'), path.join(self.directory, '.aquifer/package.json'));

--- a/src/aquifer.default.json
+++ b/src/aquifer.default.json
@@ -6,6 +6,7 @@
     "settings": "settings",
     "build": "build",
     "root": "root",
+    "drush": "drush",
     "themes": {
       "root": "themes",
       "contrib": "themes/contrib",

--- a/src/drushrc.php
+++ b/src/drushrc.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @file
+ * Custom Drush settings.
+ * @link https://github.com/drush-ops/drush/blob/master/examples/example.aliases.drushrc.php
+ */


### PR DESCRIPTION
https://github.com/aquifer/aquifer/issues/85

Testing:

``` bash
cd /var/tmp
node ~/projects/aquifer/bin/aquifer.js create drushtest
cd drushtest
node ~/projects/aquifer/bin/aquifer.js build
ls -la build/sites/all/drush
```
