### PR TITLE
Handle link creation synchronously.

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -169,7 +169,8 @@ module.exports = function (Aquifer) {
         // Create symlinks or copy.
         .then(buildStep(this.options.symlink ? 'Creating symlinks...' : 'Copying files and directories...', function () {
           var links     = [],
-              promises  = [];
+              promises  = [],
+              cwd       = process.cwd();
 
           // Installation profiles.
           if (Aquifer.project.config.paths.profiles) {
@@ -236,16 +237,8 @@ module.exports = function (Aquifer) {
               });
             });
 
-          // Create a promise for each link creation.
-          promises = links.map(function (link) {
-            var def           = new Deferred(),
-                linkCallback  = function (err) {
-                  if (err) {
-                    return def.reject(err);
-                  }
-                  def.resolve();
-                };
-
+          // Create links or copies.
+          links.forEach(function (link) {
             // Make src and dest paths absolute.
             link.dest = path.join(self.destination, link.dest);
             link.src = path.join(Aquifer.project.directory, link.src);
@@ -257,20 +250,18 @@ module.exports = function (Aquifer) {
               process.chdir(destBase);
 
               // Symlink the relative path of the src from the destination into the basename of the path.
-              fs.symlink(path.relative(destBase, link.src), path.basename(link.dest), link.type, linkCallback);
+              fs.symlinkSync(path.relative(destBase, link.src), path.basename(link.dest), link.type);
+
+              // Change the working directory back to the original.
+              process.chdir(cwd);
             }
             else {
-              fs.copy(link.src, link.dest, linkCallback);
+              fs.copySync(link.src, link.dest);
             }
-
-            return def.promise;
           });
-
-          // Return a promise for the completed creation of all links.
-          return promise.all(promises);
         }))
         // Complete the build promise chain.
-        .then(function (res) {
+        .then(function () {
           callback();
         }, function (err) {
           callback(err);


### PR DESCRIPTION
Sometimes symlinks were being created in the wrong location. I think this was because the process.chdir() was not playing well with the asynchronous handling of symlink creation. A completely synchronous approach is more stable. To that end I've removed the promise chain from the link creation and replaced it with a simple forEach. I've also set the cwd back to its original state.
