### PR TITLE
Don't filter .gitignore from root files

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -232,7 +232,7 @@ module.exports = function (Aquifer) {
           // Add core file overrides.
           fs.readdirSync(Aquifer.project.absolutePaths.root)
             .filter(function (file) {
-              return file.indexOf('.git') !== 0;
+              return file.indexOf('.gitkeep') !== 0;
             })
             .forEach(function (file) {
               // Delete existing files.


### PR DESCRIPTION
Current logic will exclude .gitignore files from the build directory. This change keeps them.

Ability to add a custom .gitignore file is useful for excluding private settings.php files from the build which can prevent these files from getting deployed with tools like `aquifer deploy-git`.

**To test:**
- Add a custom `.gitignore` file to the `/root` directory in your aquifer project.
- Run `aquifer build`
- Verify that your custom `.gitignore` file is symlinked into the base directory of your build.
