### PR TITLE
Check for existence of core files before deleting

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -235,8 +235,10 @@ module.exports = function (Aquifer) {
               return file.indexOf('.gitkeep') !== 0;
             })
             .forEach(function (file) {
-              // Delete existing files.
-              fs.unlinkSync(path.join(self.destination, file));
+              // Delete existing files if they exist.
+              if (fs.existsSync(path.join(self.destination, file))) {
+                fs.unlinkSync(path.join(self.destination, file));
+              }
 
               links.push({
                 src: path.join(Aquifer.project.config.paths.root, file),


### PR DESCRIPTION
Trying to delete a core file prior to replacing/symlinking it causes build to fail if the file doesn't already exist. This PR checks for the existence of the file in the build root before it tries to delete it.

**To test:**
- Add a `test.txt` file to the `/root` directory in an Aquifer project.
- Run `aquifer build`.
- Ensure build completes without error and `test.txt` is symlinked into the build root.
