### PR TITLE
Add to local aquifer config to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ node_modules
 
 # OSX Garbage.
 .DS_Store
+
+# Local Aquifer Config.
+aquifer.local.json


### PR DESCRIPTION
This wasn't in the default aquifer gitignore  but the local aquifer .json will contain local settings that typically won't be needed in any repo.
