### PR TITLE
Add options for adding or excluding links during a build.

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -18,7 +18,7 @@ module.exports = function (Aquifer) {
    * @param {object[]} options.excludeLinks An array of link destinations to exclude.
    * @param {object[]} options.addLinks An array additional links to create during the build.
    * @param {string} options.addLinks[].src The link source relative to the project root.
-   * @param {string} options.addLinks[].dest The link destination relative to the project root.
+   * @param {string} options.addLinks[].dest The link destination relative to the build.
    * @param {string} options.addLinks[].type The link type ("file" or "dir").
    *
    * @returns {object} Instance of Build object.

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -13,6 +13,13 @@ module.exports = function (Aquifer) {
    *
    * @param {string} destination Path to destination folder.
    * @param {object} options Configuration options for the build.
+   * @param {bool} options.symlink Whether the build should copy or symlink directories.
+   * @param {object[]} options.delPatterns Patterns indicating what should be deleted when clearing existing builds.
+   * @param {object[]} options.excludeLinks An array of link destinations to exclude.
+   * @param {object[]} options.addLinks An array additional links to create during the build.
+   * @param {string} options.addLinks[].src The link source relative to the project root.
+   * @param {string} options.addLinks[].dest The link destination relative to the project root.
+   * @param {string} options.addLinks[].type The link type ("file" or "dir").
    *
    * @returns {object} Instance of Build object.
    */
@@ -37,7 +44,9 @@ module.exports = function (Aquifer) {
     // Set default options.
     self.options = {
       symlink: true,
-      delPatterns: ['*']
+      delPatterns: ['*'],
+      excludeLinks: [],
+      addLinks: []
     };
 
     if (options) {
@@ -246,6 +255,14 @@ module.exports = function (Aquifer) {
                 type: 'file'
               });
             });
+
+          // Add links from options.
+          links = links.concat(self.options.addLinks);
+
+          // Exclude links from options.
+          links = links.filter(function (link) {
+            return self.options.excludeLinks.indexOf(link.dest) === -1;
+          });
 
           // Create links or copies.
           links.forEach(function (link) {


### PR DESCRIPTION
This PR adds the ability for options to be passed to the build API to allow links to be excluded or added from the default set that get symlinked or copied on build.
