### PR TITLE
Change refresh order

### DIFF
--- a/src/aquifer.default.json
+++ b/src/aquifer.default.json
@@ -25,19 +25,19 @@
   "extensions": {},
   "refreshCommands": [
     [
-      "updb"
-    ],
-    [
-      "cc",
-      "all"
-    ],
-    [
       "en",
       "master"
     ],
     [
       "master-execute",
       "--scope=local"
+    ],
+    [
+      "updb"
+    ],
+    [
+      "cc",
+      "all"
     ],
     [
       "fra"


### PR DESCRIPTION
Here is a suggestion revision for the order of refresh operations.  This would allow update hooks to be based on recently enabled modules. If an enabled module needs to make revisions outside of its own concerns it still can do this within an install hook.  This solves the problem of trying to deploy and unenabled module (say a contrib module) with a cross cutting update_N hook in a feature perhaps.
