### PR TITLE
Post build hook API

### DIFF
--- a/bin/aquifer.js
+++ b/bin/aquifer.js
@@ -27,6 +27,10 @@ Aquifer.api = {
 // Initialize.
 Aquifer.init.setup();
 
+// Post Builds.
+// Extensions can declare a postBuild function that must return a promise.
+Aquifer.postBuilds = [];
+
 // Commands.
 Aquifer.command = {
   create: require('../lib/create.command.js')(Aquifer),

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -84,7 +84,7 @@ module.exports = function (Aquifer) {
       // If there was an exception, the make file probably doesn't exist.
       catch (error) {
         Aquifer.console.log(error, 'error');
-        return;
+        return false;
       }
 
       /**
@@ -299,6 +299,33 @@ module.exports = function (Aquifer) {
         }, function (err) {
           callback(err);
         });
+    };
+
+    /**
+     * Run postBuild hooks loaded by extensions.
+     *
+     * @returns {function} chaiable promise.
+     */
+    self.postBuild = function () {
+      var group, postBuildPromises; 
+
+      if (Aquifer.postBuilds.length < 1) {
+        throw new Error('No post build hooks to run!');
+      }
+
+      postBuildPromises = Aquifer.postBuilds.map(function(postBuild) {
+        return postBuild();
+      });
+
+      group = promise.all(postBuildPromises);
+
+      return group.then(function() {
+        Aquifer.console.log('Post build hooks ran successfully!', 'success');
+      })
+      .then(null, function(error) {
+        Aquifer.console.log('There was a problem running postBuilds!', 'error');
+        throw new Error(error);
+      });
     };
 
     return self;

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -307,11 +307,7 @@ module.exports = function (Aquifer) {
      * @returns {function} chaiable promise.
      */
     self.postBuild = function () {
-      var group, postBuildPromises; 
-
-      if (Aquifer.postBuilds.length < 1) {
-        throw new Error('No post build hooks to run!');
-      }
+      var group, postBuildPromises;
 
       postBuildPromises = Aquifer.postBuilds.map(function(postBuild) {
         return postBuild();
@@ -319,8 +315,10 @@ module.exports = function (Aquifer) {
 
       group = promise.all(postBuildPromises);
 
-      return group.then(function() {
-        Aquifer.console.log('Post build hooks ran successfully!', 'success');
+      return group.then(function(results) {
+        if (results.length) {
+          Aquifer.console.log('Post build hooks ran successfully!', 'success');
+        }
       })
       .then(null, function(error) {
         Aquifer.console.log('There was a problem running postBuilds!', 'error');

--- a/lib/build.command.js
+++ b/lib/build.command.js
@@ -35,7 +35,12 @@ module.exports = function (Aquifer) {
         Aquifer.console.log(error, 'error');
       }
       else {
-        Aquifer.console.log(settings.name + ' build created successfully!', 'success');
+      Aquifer.console.log(settings.name + ' build created successfully!', 'success');
+
+      build.postBuild()
+        .then(null, function(error) {
+          Aquifer.console.log(error, 'error');
+        });
       }
     });
   });

--- a/lib/build.command.js
+++ b/lib/build.command.js
@@ -35,12 +35,12 @@ module.exports = function (Aquifer) {
         Aquifer.console.log(error, 'error');
       }
       else {
-      Aquifer.console.log(settings.name + ' build created successfully!', 'success');
+        Aquifer.console.log(settings.name + ' build created successfully!', 'success');
 
-      build.postBuild()
-        .then(null, function(error) {
-          Aquifer.console.log(error, 'error');
-        });
+        build.postBuild()
+          .then(null, function(error) {
+            Aquifer.console.log(error, 'error');
+          });
       }
     });
   });

--- a/lib/extension.command.js
+++ b/lib/extension.command.js
@@ -10,7 +10,8 @@ module.exports = function (Aquifer) {
 
   var _          = require('lodash'),
       extensions = {},
-      extensionCommands, command, extension;
+      extensionCommands, command, extension,
+      extensionPostBuilds, postBuild;
 
   // If there is no aquifer project, do not initialize extension commands.
   if (!Aquifer.initialized) {
@@ -133,39 +134,47 @@ module.exports = function (Aquifer) {
       return;
     }
 
-    // If there is no '.commands()' function on this module, error out and exit.
-    if (typeof extensions[extensionName].commands !== 'function') {
-      Aquifer.console.log(extension.extensionName + ': Aquifer extension npm modules must return an object with an .commands() function', 'error');
+
+    if (typeof extensions[extensionName].commands !== 'function' && typeof extensions[extensionName].postBuild !== 'function') {
+      Aquifer.console.log(extension.extensionName + ': Aquifer extension npm modules must return an object with either a .commands() or .postBuild() function.', 'error');
       return;
     }
 
-    // Retrieve extension info.
-    extensionCommands = extensions[extensionName].commands();
+    // If there is a '.commands()' function, create its commands.
+    if (typeof extensions[extensionName].commands == 'function') {
+      // Retrieve extension info.
+      extensionCommands = extensions[extensionName].commands();
 
-    // Create commands from extension.
-    _.each(extensionCommands, function (config, commandName) {
-      command = Aquifer.cli.command(commandName);
-      command.description(config.description);
+      // Create commands from extension.
+      _.each(extensionCommands, function (config, commandName) {
+        command = Aquifer.cli.command(commandName);
+        command.description(config.description);
 
-      if (config.options) {
-        _.each(config.options, function (option) {
-          command.option(option.name, option.description, option.default || null);
-        });
-      }
+        if (config.options) {
+          _.each(config.options, function (option) {
+            command.option(option.name, option.description, option.default || null);
+          });
+        }
 
-      if (config.allowUnknownOption) {
-        command.allowUnknownOption();
-      }
+        if (config.allowUnknownOption) {
+          command.allowUnknownOption();
+        }
 
-      command.action(function (options) {
-        options = options || {};
+        command.action(function (options) {
+          options = options || {};
 
-        extensions[extensionName].run(commandName, options, function (err) {
-          if (err) {
-            Aquifer.console.log(err, 'error');
-          }
+          extensions[extensionName].run(commandName, options, function (err) {
+            if (err) {
+              Aquifer.console.log(err, 'error');
+            }
+          });
         });
       });
-    });
+    }
+
+    // If there is a '.postBuild()' function on this module, add it.
+    if (typeof extensions[extensionName].postBuild == 'function') {
+      Aquifer.postBuilds.push(extensions[extensionName].postBuild);
+    }
   });
 };


### PR DESCRIPTION
The command API is in flux currently and I don't expect this to be merged straight away, but I was bored last night and this was a good way to get my feet wet with the codebase. At the very least, this PR can be considered a rough POC for post build (or post command) hooks.

ATM, the way I implemented this is that a `postBuild` hook is just a function exposed by an extension that returns a promise. Aquifer gathers all postBuilds from extensions during `extensions-load` and a simple postBuilds function was added to the build API that calls all postBuilds after a succesful build.

This work could probably be abstracted into a postCommand type of API once the command API is flushed out that could be applied to refresh, build, etc.. That way the abstraction wouldn't leak all the way up to the Aquifer object.

You can see https://github.com/infiniteluke/aquifer-done/blob/master/aquifer-done.js#L30 as an example postBuild I used for testing.
## Test
- checkout `postBuild` in mah fork
- Run `aquifer create test && cd test`
- Load [aquifer-done](https://github.com/infiniteluke/aquifer-done) extension fork.
  - See README on aquifer-done repo for how to get this working locally since it isn't published to NPM.
- `aquifer extensions-load`
- `aquifer build`
- See a notification popup after the build is complete.
## Notes:
- This PR changes the requirement of the .commands() function in an extensions to require either a .commands() _or_ a .postBuild() to make post build only extensions possible.
- What if someone whats to just run gulp after build? Maybe we shouldn't have write an extension for every postBuild command we want to run. Should we allow arbitrary cli commands?
- The commands API is in flux
