### PR TITLE
Local aquifer.json fixes

### DIFF
--- a/lib/extension.command.js
+++ b/lib/extension.command.js
@@ -97,6 +97,11 @@ module.exports = function (Aquifer) {
 
     var extension;
     _.each(Aquifer.project.config.extensions, function(config, name) {
+      // If this extension is false, exit.
+      if (config === false) {
+        return;
+      }
+
       extension = new Aquifer.api.extension(name);
       extension.download(function (err) {
         if (err) {

--- a/lib/extension.command.js
+++ b/lib/extension.command.js
@@ -119,6 +119,11 @@ module.exports = function (Aquifer) {
    * Loop through and initialize all commands created by extensions.
    */
   _.each(Aquifer.project.config.extensions, function(config, extensionName) {
+    // Do not load if this extension is false.
+    if (config === false) {
+      return;
+    }
+
     // Require/load the extension module.
     extension = new Aquifer.api.extension(extensionName);
     extensions[extensionName] = extension.load(function (err) {

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -40,7 +40,7 @@ module.exports = function (Aquifer) {
 
       // Extend config with aquifer.local.json.
       if (fs.existsSync(localJsonPath)) {
-        _.merge(self.config, jsonFile.readFileSync(localJsonPath));
+        self.config = _.defaultsDeep(jsonFile.readFileSync(localJsonPath), self.config);
       }
     }
     // If this is a new (uninitialized) project, load the default json.


### PR DESCRIPTION
This PR makes a couple of changes...
1) Prioritizes local config over global config. This means that properties can be overridden consistently.
2) Uses `_.deepDefault` to calculate project config between local and global config.
3) Modifies the extensions API so that it does not load extensions that are set to "false" in the config.
## Steps to test
- Checkout this branch.
- Run `aquifer create test && cd test`
- Add an extension to your project: `aquifer extension-add aquifer-coder`
- Create an `aquifer.local.json` file
- Set the "extensions" property in your local json file to an object formed like this:

``` javascript
{
  "extensions": {
    "aquifer-coder": false
  }
}
```
- Run `aquifer` in your project and ensure that `jslint`, `phplint`, and `lint` do not exist in the list of documented commands.
