### PR TITLE
Add copy and directory flags to allow more flexibility from the command line.

### DIFF
--- a/lib/build.command.js
+++ b/lib/build.command.js
@@ -20,15 +20,20 @@ module.exports = function (Aquifer) {
   .description('Construct the framework of the site using contents of custom modules, themes, and projects defined in Drush Make.')
   .option('-m, --make', 'Force a build from the make file. Lock file will not be rewritten.')
   .option('-r, --refresh-lock', 'Regenerate the lock file from the make file.')
+  .option('-c, --copy', 'Copy directories instead of creating symlinks.')
+  .option('-d, --directory <path>', 'The destination directory in which to build.')
   .action(function (options) {
-    var path      = require('path'),
-        settings  = Aquifer.project.config,
-        makeFile  = path.join(Aquifer.projectDir, settings.paths.make),
-        lockFile  = settings.paths.lock !== false ? path.join(Aquifer.projectDir, settings.paths.lock) : false,
-        make      = options.make === true,
+    var path        = require('path'),
+        settings    = Aquifer.project.config,
+        makeFile    = path.join(Aquifer.projectDir, settings.paths.make),
+        lockFile    = settings.paths.lock !== false ? path.join(Aquifer.projectDir, settings.paths.lock) : false,
+        make        = options.make === true,
         refreshLock = lockFile !== false && options.refreshLock === true,
-        directory = settings.paths.build,
-        build     = new Aquifer.api.build(directory);
+        copy        = options.copy === true,
+        directory   = options.directory || settings.paths.build,
+        build       = new Aquifer.api.build(directory, {
+          symlink: !copy
+        });
 
     build.create(make, refreshLock, makeFile, lockFile, function(error) {
       if (error) {


### PR DESCRIPTION
Now you can do something like this:

`aquifer build --copy --directory ~/workspace/test-build`

and you will build a Drupal codebase at ~/workspace/test-build without symlinks.
