### PR TITLE
Improved linking validation

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -269,16 +269,22 @@ module.exports = function (Aquifer) {
             // Make src and dest paths absolute.
             link.dest = path.join(self.destination, link.dest);
             link.src = path.join(Aquifer.project.directory, link.src);
+            var destBase = path.dirname(link.dest);
+
+            // If the source doesn't exist, skip this link.
+            if (!fs.existsSync(link.src)) {
+              Aquifer.console.log('Source file does not exist. Skipping: ' + link.src, 'status');
+              return;
+            }
+
+            // Make sure the destination base path exists.
+            if (!fs.existsSync(destBase)) {
+              Aquifer.console.log('Destination directory does not exist. Creating: ' + destBase, 'status');
+              fs.mkdirSync(destBase);
+            }
 
             // If symlinking is turned on, symlink custom files. Else, copy.
             if (self.options.symlink) {
-              var destBase = path.dirname(link.dest);
-
-              // Make sure the destination base path exists.
-              if (!fs.existsSync(destBase)) {
-                fs.mkdirSync(destBase);
-              }
-
               // Change current directory to the destination base path (minus last part of path).
               process.chdir(destBase);
 


### PR DESCRIPTION
- Checks that source exists before attempting to link/copy and skips if it does not. Prevents build from failing should a defined source not exist. Shouldn't normally be an issue but provides a failsafe. I ran into this for example on an older project after pulling down the latest from the Aquifer dev branch. The project didn't have the newer `/drush` directory in it and `deploy-git` was failing.
- Creates destination path if it doesn't exist when copying as well. Previously we just did this when symlinking.

**To test:**
- Create a project with aquifer-git enabled and configured
- Delete the `/drush` directory from your project.
- Run `aquifer deploy-git`
- You should see a message during the build that drush directory was skipped and the deployment should complete successfully.
