### PR TITLE
Checking if an existing non-aquifer directory is in the way

### DIFF
--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -31,8 +31,11 @@ module.exports = function (Aquifer) {
     // Set directory, name, and status. Directory is required!
     self.directory = directory || Aquifer.cwd;
 
+    // Directory exists on file system?
+    self.exists = fs.existsSync(self.directory);
+
     // Decide whether or not this is initialized already.
-    self.initialized = fs.existsSync(self.directory) || fs.existsSync(jsonPath) ? true : false;
+    self.initialized = self.exists && fs.existsSync(jsonPath) ? true : false;
 
     // If this project is initialized, load the JSON path.
     if (self.initialized) {
@@ -96,7 +99,7 @@ module.exports = function (Aquifer) {
      * @returns {boolean} false if this project is already initialized, true if create completes.
      */
     self.create = function(callback) {
-      if (self.initialized === true) {
+      if (self.initialized === true || self.exists === true) {
         callback(self.directory + ' already exists, or is already an aquifer project.');
         return false;
       }


### PR DESCRIPTION
Aquifer fails with a big nasty fs.js error if you have a directory with the same name as your new project and run `aquifer create`. This patch triggers the friendly error message and makes the `self.initialized` check a little more picky so that just a directory being there doesn't pass the condition.
