### PR TITLE
HOTFIX - default core version for legacy projects.

### DIFF
--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -201,7 +201,7 @@ class Project {
    * Does all the leg-work of setting the major drupal version.
    *
    * @param {int} version the major version number of the drupal build.
-   * @returns {object} project object for chaining.
+   * @returns {undefined} nothing.
    */
   setDrupalVersion(version) {
     const destPaths = {

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -35,7 +35,7 @@ class Project {
     this.drupalVersion = drupalVersion || 7;
     this.srcDir = '';
     this.destPaths = {};
-    this.setDrupalVersion(this.drupalVersion)
+    this.setDrupalVersion(this.drupalVersion);
 
     // If this Aquifer project has already been created, load it.
     if (Aquifer.initialized) {
@@ -88,6 +88,8 @@ class Project {
         this.config.name = name || path.basename(directory);
       }
 
+      // If this project has no defined core version, default to 7.
+      this.config.core = this.config.core || this.drupalVersion;
       this.setDrupalVersion(this.config.core);
 
       // Define absolute paths to assets.
@@ -222,7 +224,6 @@ class Project {
     this.drupalVersion = version;
     this.srcDir = path.join(path.dirname(fs.realpathSync(__filename)), '../src', 'd' + this.drupalVersion);
     this.destPaths = destPaths[version];
-    return this;
   }
 }
 


### PR DESCRIPTION
This PR introduces a fix that defaults the drupal core version to Drupal 7 for legacy projects that might have been initialized post the D8 update.

It also removes an un-needed return statement from one of the functions.
## Steps to test
- Run `aquifer create test -d 7`
- Edit the newly created aquifer.json file and remove the `core` property.
- Run `aquifer build` and ensure it completes properly.
