### PR TITLE
HOTFIX - Extension API

### DIFF
--- a/lib/extension.api.js
+++ b/lib/extension.api.js
@@ -139,8 +139,7 @@ class Extension {
         fs.mkdirSync(vendor);
 
         // Copy src/package.json into .aquifer/package.json.
-        var srcDir = path.join(path.dirname(fs.realpathSync(__filename)), '../src');
-        fs.copySync(path.join(srcDir, 'package.json'), path.join(vendor, 'package.json'));
+        fs.copySync(path.join(this.aquifer.project.srcDir, 'package.json'), path.join(vendor, 'package.json'));
       }
 
       // Download the extensions.

--- a/src/d7/package.json
+++ b/src/d7/package.json
@@ -1,2 +1,7 @@
 {
+  "name": "aquifer",
+  "version": "0.1.4",
+  "description": "Drupal build, test, and deployment CLI.",
+  "license": "GPL-2.0",
+  "repository": "none"
 }

--- a/src/d8/package.json
+++ b/src/d8/package.json
@@ -1,2 +1,7 @@
 {
+  "name": "aquifer",
+  "version": "0.1.4",
+  "description": "Drupal build, test, and deployment CLI.",
+  "license": "GPL-2.0",
+  "repository": "none"
 }


### PR DESCRIPTION
This PR fixes the extension API so that it is compatible with the new Drupal major version specific src directory.
## Steps to test
- Checkout this branch.
- In an existing project, delete the `.aquifer` directory.
- Run `aquifer extensions-load` and ensure it completes.
- Ensure that there are no `package.json does not contain *` errors.
