### PR TITLE
Only connect once with invokeAll on a remote env

### DIFF
--- a/lib/run.api.js
+++ b/lib/run.api.js
@@ -64,36 +64,47 @@ class Run {
 
   /**
    * Invoke a command on an environment.
-   * @param {string} command The command to invoke.
+   * @param {string|array} commands The command or set of commands to invoke.
    * @param {string} env The name of the environment on which to invoke.
    * @returns {object} promist object.
    */
-  invokeOnEnv(command, env) {
+  invokeOnEnv(commands, env) {
     return new Promise((resolve, reject) => {
       let environment = new this.aquifer.api.environment(this.aquifer, env);
 
-      environment.connect((connection) => {
-        return new Promise((resolve, reject) => {
-          connection.exec('cd ' + environment.config.paths.drupal + ' && ' + command, (err, stream) => {
-            if (err) {
-              reject(err);
-            }
+      // Make sure commands is an array.
+      commands = commands.constructor !== Array ? [commands] : commands;
 
-            stream
-            .on('close', (code, signal) => {
-              if (code !== 0) {
-                reject('Command exited with code ' + code + ' on environment ' + env);
-              }
-              resolve();
-            })
-            .on('data', (data) => {
-              this.aquifer.console.log(data.toString('utf8').trim());
-            })
-            .stderr.on('data', (data) => {
-              this.aquifer.console.log(data.toString('utf8').trim());
+      environment.connect((connection) => {
+        let chain = Promise.resolve();
+
+        commands.forEach((command) => {
+          chain = chain.then(() => {
+            return new Promise((resolve, reject) => {
+              connection.exec('cd ' + environment.config.paths.drupal + ' && ' + command, (err, stream) => {
+                if (err) {
+                  reject(err);
+                }
+
+                stream
+                .on('close', (code, signal) => {
+                  if (code !== 0) {
+                    reject('Command exited with code ' + code + ' on environment ' + env);
+                  }
+                  resolve();
+                })
+                .on('data', (data) => {
+                  this.aquifer.console.log(data.toString('utf8').trim());
+                })
+                .stderr.on('data', (data) => {
+                  this.aquifer.console.log(data.toString('utf8').trim());
+                })
+              })
             })
           })
         })
+
+        return chain;
       })
       .catch((reason) => {
         reject(reason);
@@ -112,6 +123,11 @@ class Run {
    * @returns {object} promise object.
    */
   invokeAll(commands, options, env) {
+    // Invoke on an environment.
+    if (typeof env !== 'undefined') {
+      return this.invokeOnEnv(commands, env);
+    }
+
     let chain = Promise.resolve()
 
     // Execute the command chain.


### PR DESCRIPTION
We only need to connect once with invokeAll on an environment. Without this, it was especially frustrating if you have an encrypted private key since you get prompted for each command.
## To Review:
- [ ] Run a multi-command run script against a remote environment and make sure everything works correctly. Bonus points if you can test this with an encrypted private key so you can see that you are only prompted for your password once.
