### PR TITLE
Bump version in package.json and aquifer lib

### DIFF
--- a/lib/aquifer.api.js
+++ b/lib/aquifer.api.js
@@ -20,7 +20,7 @@ class Aquifer {
    * @returns {undefined} nothing.
    */
   constructor() {
-    this.version = '0.1.4';
+    this.version = '1.0.0-beta1';
     this.cli = require('commander');
     this.cwd = process.cwd();
     this.initialized = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquifer",
-  "version": "0.1.4",
+  "version": "1.0.0-beta1",
   "description": "Drupal build, test, and deployment CLI.",
   "scripts": {
     "test-unit": "node_modules/.bin/mocha test/unit/*",


### PR DESCRIPTION
This PR simply bumps the version number in package.json and the aquifer library to 1.0.0-beta1.
