### PR TITLE
Document beta release installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ Aquifer is an npm module, installing it is relatively painless:
 * Ensure that the latest version of Node.js and npm are installed. We recommend using [nvm](https://github.com/creationix/nvm) to do this.
 * Install [Drush](http://www.drush.org/en/master/install/). Aquifer is compatible with Drush 7.x and 6.x.
 * In your command line, run: `npm install -g aquifer`
-* There is currently a beta release which contains significant updates. To install this beta, run: `npm install -g aquifer/aquifer#1.0.0-beta1`
+
+Aquifer has a beta version that contains significant updates. If you would like to install this beta, run the following:
+```bash
+npm install -g aquifer/aquifer#1.0.0-beta1`
+```
 
 Aquifer should now be installed!
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Aquifer is an npm module, installing it is relatively painless:
 * Ensure that the latest version of Node.js and npm are installed. We recommend using [nvm](https://github.com/creationix/nvm) to do this.
 * Install [Drush](http://www.drush.org/en/master/install/). Aquifer is compatible with Drush 7.x and 6.x.
 * In your command line, run: `npm install -g aquifer`
+* There is currently a beta release which contains significant updates. To install this beta, run: `npm install -g aquifer/aquifer#1.0.0-beta1`
 
 Aquifer should now be installed!
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,7 @@ Aquifer is an npm module, installing it is relatively painless:
 * Ensure that the latest version of Node.js and npm are installed. We recommend using [nvm](https://github.com/creationix/nvm) to do this.
 * Install [Drush](http://www.drush.org/en/master/install/). Aquifer is compatible with Drush 7.x and 6.x.
 * In your command line, run: `npm install -g aquifer`
-
-Aquifer has a beta version that contains significant updates. If you would like to install this beta, run the following:
-```bash
-npm install -g aquifer/aquifer#1.0.0-beta1`
-```
+* To install the Aquifer beta instead, run: `npm install -g aquifer@1.0.0-beta1`
 
 Aquifer should now be installed!
 


### PR DESCRIPTION
This PR adds some documentation that outlines the ability for users to install the beta release of this project from the `1.0.0-beta1` tag.
