### PR TITLE
Configurable directories

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -73,4 +73,4 @@ The new default configuration looks something like this:
 
 Note that many of the directories previously defined in the `paths` object are now configured in the `sync` object. 
 
-Project created with older versions of Aquifer will need to modify their `aquifer.json` configuration to reflect this new format relative to the directories and files they are syncing into the build.
+Projects created with older versions of Aquifer will need to modify their `aquifer.json` configuration to reflect this new format relative to the directories and files they are syncing into the build.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -1,0 +1,76 @@
+## New aquifer.json directory configuration
+
+The configuration for Drupal directories in `aquifer.json` has changed.
+
+The new default configuration looks something like this:
+
+```
+{
+  "name": "aquifer-d8",
+  "core": 8,
+  "paths": {
+    "make": "drupal.make.yml",
+    "lock": false,
+    "build": "build"
+  },
+  "sync": {
+    "directories": {
+      "modules/custom": {
+        "destination": "modules/custom",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "themes/custom": {
+        "destination": "themes/custom",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "files": {
+        "destination": "sites/default/files",
+        "method": "symlink",
+        "conflict": "overwrite"
+      }
+    },
+    "files": {
+      "root/.htaccess": {
+        "destination": ".htaccess",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "root/robots.txt": {
+        "destination": "robots.txt",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "settings/settings.php": {
+        "destination": "sites/default/settings.php",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "settings/secret.settings.php": {
+        "destination": "sites/default/secret.settings.php",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "settings/local.settings.php": {
+        "destination": "sites/default/local.settings.php",
+        "method": "symlink",
+        "conflict": "overwrite"
+      }
+    }
+  },
+  "run": {
+    "scripts": {
+      "refresh": [
+        "drush updb -y",
+        "drush cr -y"
+      ]
+    }
+  },
+  "extensions": {}
+}
+```
+
+Note that many of the directories previously defined in the `paths` object are now configured in the `sync` object. 
+
+Project created with older versions of Aquifer will need to modify their `aquifer.json` configuration to reflect this new format relative to the directories and files they are syncing into the build.

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -198,7 +198,7 @@ class Build {
             fs.copySync(link.src, link.dest);
           }
           // Create symlink
-          else
+          else {
             // Change current directory to the destination base path (minus last part of path).
             process.chdir(destBase);
 

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -189,7 +189,7 @@ class Build {
           // Make sure the destination base path exists.
           if (!fs.existsSync(destBase)) {
             this.aquifer.console.log('Destination directory does not exist. Creating: ' + destBase, 'status');
-            fs.mkdirSync(destBase);
+            fs.mkdirsSync(destBase);
           }
 
           // If symlinking is not turned on or the individual link method is
@@ -198,7 +198,7 @@ class Build {
             fs.copySync(link.src, link.dest);
           }
           // Create symlink
-          else {
+          else
             // Change current directory to the destination base path (minus last part of path).
             process.chdir(destBase);
 

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -103,7 +103,7 @@ class Build {
         let links = [];
         let project = this.aquifer.project;
         // We don't need to distinguish between directories and files at this
-        // point so lt's combine the config.
+        // point so let's combine the config.
         let syncItems = _.defaults(project.config.sync.directories, project.config.sync.files);
 
         // Add items to the links array.

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -108,8 +108,7 @@ class Build {
           Object.keys(project.config.paths.profiles).forEach((key) => {
             links.push({
               src: project.config.paths.profiles[key],
-              dest: path.join(project.destPaths.profiles, key),
-              type: 'dir'
+              dest: path.join(project.destPaths.profiles, key)
             });
           });
         }
@@ -118,38 +117,38 @@ class Build {
         if (project.config.paths.drush) {
           links.push({
             src: project.config.paths.drush,
-            dest: project.destPaths.drush,
-            type: 'dir'
+            dest: project.destPaths.drush
           });
         }
 
-        // Add module links.
-        Object.keys(project.config.paths.modules).forEach((key) => {
-          if (key !== 'root' && key !== 'contrib') {
-            links.push({
-              src: project.config.paths.modules[key],
-              dest: path.join(project.destPaths.modules, key),
-              type: 'dir'
-            });
-          }
-        });
+        // Add directories.
+        Object.keys(project.config.directories).forEach((key) => {
 
-        // Add themes links.
-        Object.keys(project.config.paths.themes).forEach((key) => {
-          if (key !== 'root' && key !== 'contrib') {
-            links.push({
-              src: project.config.paths.themes[key],
-              dest: path.join(project.destPaths.themes, key),
-              type: 'dir'
-            });
-          }
-        });
+          if (fs.existsSync(path.join(project.directory, key))) {
+            let data = project.config.directories[key];
 
-        // Add files link.
-        links.push({
-          src: project.config.paths.files.root,
-          dest: path.join(project.destPaths.site, 'files'),
-          type: 'dir'
+            if (data.destination) {
+
+              links.push({
+                src: key,
+                dest: data.destination
+              });
+            }
+            else {
+              fs.readdirSync(path.join(project.directory, key))
+              .filter((item) => {
+                return item.indexOf('.gitkeep') !== 0;
+              })
+              .forEach((item) => {
+                let itemPath = path.join(project.directory, key, item);
+
+                links.push({
+                  src: path.join(key, item),
+                  dest: item
+                });
+              });
+            }
+          }
         });
 
         // Add settings files links.
@@ -160,28 +159,9 @@ class Build {
           .forEach((file) => {
             links.push({
               src: path.join(project.config.paths.settings, file),
-              dest: path.join(project.destPaths.site, file),
-              type: 'file'
+              dest: path.join(project.destPaths.site, file)
             });
           });
-
-        // Add core file overrides.
-        fs.readdirSync(project.absolutePaths.root)
-        .filter((file) => {
-          return file.indexOf('.gitkeep') !== 0;
-        })
-        .forEach((file) => {
-          // Delete existing files if they exist.
-          if (fs.existsSync(path.join(this.destination, file))) {
-            fs.unlinkSync(path.join(this.destination, file));
-          }
-
-          links.push({
-            src: path.join(project.config.paths.root, file),
-            dest: file,
-            type: 'file'
-          });
-        });
 
         // Add links from options.
         links = links.concat(this.options.addLinks);
@@ -200,6 +180,11 @@ class Build {
           link.dest = path.join(this.destination, link.dest);
           link.src = path.join(project.directory, link.src);
           let destBase = path.dirname(link.dest);
+          let type = 'file';
+
+          if (fs.statSync(link.src).isDirectory()) {
+            type = 'dir';
+          }
 
           // If the source doesn't exist, skip this link.
           if (!fs.existsSync(link.src)) {
@@ -213,9 +198,13 @@ class Build {
             fs.mkdirSync(destBase);
           }
 
+          // Delete existing files if they exist.
+          if (fs.existsSync(link.dest)) {
+            fs.unlinkSync(link.dest);
+          }
+
           // If symlinking is turned on, symlink custom files. Else, copy.
           if (this.options.symlink) {
-
             // Make sure the destination base path exists.
             if (!fs.existsSync(destBase)) {
               fs.mkdirSync(destBase);
@@ -225,7 +214,7 @@ class Build {
             process.chdir(destBase);
 
             // Symlink the relative path of the src from the destination into the basename of the path.
-            fs.symlinkSync(path.relative(destBase, link.src), path.basename(link.dest), link.type);
+            fs.symlinkSync(path.relative(destBase, link.src), path.basename(link.dest), type);
 
             // Change the working directory back to the original.
             process.chdir(this.aquifer.cwd);

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -179,7 +179,7 @@ class Build {
 
               case 'skip':
                 this.aquifer.console.log('Destination exists. Conflict set to skip. \nSkipping: ' + link.dest, 'status');
-                return 3;
+                return false;
 
               default:
                 return false;

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -102,66 +102,43 @@ class Build {
         this.aquifer.console.log(this.options.symlink ? 'Creating symlinks...' : 'Copying files and directories...');
         let links = [];
         let project = this.aquifer.project;
+        // We don't need to distinguish between directories and files at this
+        // point so lt's combine the config.
+        let syncItems = _.defaults(project.config.sync.directories, project.config.sync.files);
 
-        // Add installation profiles.
-        if (project.config.paths.profiles) {
-          Object.keys(project.config.paths.profiles).forEach((key) => {
-            links.push({
-              src: project.config.paths.profiles[key],
-              dest: path.join(project.destPaths.profiles, key)
-            });
-          });
-        }
-
-        // Add Drush files.
-        if (project.config.paths.drush) {
-          links.push({
-            src: project.config.paths.drush,
-            dest: project.destPaths.drush
-          });
-        }
-
-        // Add directories.
-        Object.keys(project.config.directories).forEach((key) => {
-
+        // Add items to the links array.
+        Object.keys(syncItems).forEach((key) => {
+          // Make sure the source exists in the project.
           if (fs.existsSync(path.join(project.directory, key))) {
-            let data = project.config.directories[key];
+            let data = syncItems[key];
 
-            if (data.destination) {
-
-              links.push({
-                src: key,
-                dest: data.destination
+            // If destination is the Drupal root and the source is a directory
+            // assume we want to copy/sync the contents. Iterate over contents
+            // add them to the links array individually.
+            if (!data.destination && fs.statSync(key).isDirectory()) {
+              fs.readdirSync(path.join(project.directory, key))
+                .filter((item) => {
+                  return item.indexOf('.gitkeep') !== 0;
+              })
+              .forEach((item) => {
+                links.push({
+                  src: path.join(key, item),
+                  dest: item,
+                  method: data.method,
+                  conflict: data.conflict
+                });
               });
             }
             else {
-              fs.readdirSync(path.join(project.directory, key))
-              .filter((item) => {
-                return item.indexOf('.gitkeep') !== 0;
-              })
-              .forEach((item) => {
-                let itemPath = path.join(project.directory, key, item);
-
-                links.push({
-                  src: path.join(key, item),
-                  dest: item
-                });
+              links.push({
+                src: key,
+                dest: data.destination,
+                method: data.method,
+                conflict: data.conflict
               });
             }
           }
         });
-
-        // Add settings files links.
-        fs.readdirSync(project.absolutePaths.settings)
-          .filter((file) => {
-            return file.indexOf('.') !== 0;
-          })
-          .forEach((file) => {
-            links.push({
-              src: path.join(project.config.paths.settings, file),
-              dest: path.join(project.destPaths.site, file)
-            });
-          });
 
         // Add links from options.
         links = links.concat(this.options.addLinks);
@@ -174,7 +151,7 @@ class Build {
         // Create links or copies.
         links.forEach((link) => {
           // Log this to the user.
-          this.aquifer.console.log((this.options.symlink ? 'Symlinking ' : 'Copying ') + link.src + ' => ' + link.dest)
+          this.aquifer.console.log(((!this.options.symlink || link.method === 'copy') ? 'Copying ' : 'Symlinking ') + link.src + ' => ' + link.dest)
 
           // Make src and dest paths absolute. Determine destination base path.
           link.dest = path.join(this.destination, link.dest);
@@ -189,7 +166,24 @@ class Build {
           // If the source doesn't exist, skip this link.
           if (!fs.existsSync(link.src)) {
             this.aquifer.console.log('Source file does not exist. Skipping: ' + link.src, 'status');
-            return;
+            return false;
+          }
+
+          // Handle existing destinations.
+          if (fs.existsSync(link.dest)) {
+            switch (link.conflict) {
+              case 'overwrite':
+                this.aquifer.console.log('Destination exists. Conflict set to overwrite. \nOverwriting: ' + link.dest, 'status');
+                fs.unlinkSync(link.dest);
+                break;
+
+              case 'skip':
+                this.aquifer.console.log('Destination exists. Conflict set to skip. \nSkipping: ' + link.dest, 'status');
+                return 3;
+
+              default:
+                return false;
+            }
           }
 
           // Make sure the destination base path exists.
@@ -198,18 +192,13 @@ class Build {
             fs.mkdirSync(destBase);
           }
 
-          // Delete existing files if they exist.
-          if (fs.existsSync(link.dest)) {
-            fs.unlinkSync(link.dest);
+          // If symlinking is not turned on or the individual link method is
+          // copy, copy the item.
+          if (!this.options.symlink || link.method === 'copy') {
+            fs.copySync(link.src, link.dest);
           }
-
-          // If symlinking is turned on, symlink custom files. Else, copy.
-          if (this.options.symlink) {
-            // Make sure the destination base path exists.
-            if (!fs.existsSync(destBase)) {
-              fs.mkdirSync(destBase);
-            }
-
+          // Create symlink
+          else {
             // Change current directory to the destination base path (minus last part of path).
             process.chdir(destBase);
 
@@ -218,9 +207,6 @@ class Build {
 
             // Change the working directory back to the original.
             process.chdir(this.aquifer.cwd);
-          }
-          else {
-            fs.copySync(link.src, link.dest);
           }
         })
       })

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -119,15 +119,15 @@ class Build {
               fs.readdirSync(path.join(project.directory, key))
                 .filter((item) => {
                   return item.indexOf('.gitkeep') !== 0;
-              })
-              .forEach((item) => {
-                links.push({
-                  src: path.join(key, item),
-                  dest: item,
-                  method: data.method,
-                  conflict: data.conflict
+                })
+                .forEach((item) => {
+                  links.push({
+                    src: path.join(key, item),
+                    dest: item,
+                    method: data.method,
+                    conflict: data.conflict
+                  });
                 });
-              });
             }
             else {
               links.push({

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -96,24 +96,7 @@ class Project {
       this.absolutePaths = {
         json: jsonPath,
         make: path.join(directory, this.config.paths.make),
-        settings: path.join(directory, this.config.paths.settings),
-        //root: path.join(directory, this.config.paths.root),
-        drush: path.join(directory, this.config.paths.drush),
         build: path.join(directory, this.config.paths.build),
-        //themes: {
-        //  root: path.join(directory, this.config.paths.themes.root),
-        //  contrib: path.join(directory, this.config.paths.themes.contrib),
-        //  custom: path.join(directory, this.config.paths.themes.custom)
-        //},
-        //modules: {
-        //  root: path.join(directory, this.config.paths.modules.root),
-        //  contrib: path.join(directory, this.config.paths.modules.contrib),
-        //  custom: path.join(directory, this.config.paths.modules.custom),
-        //  features: path.join(directory, this.config.paths.modules.features)
-        //},
-        //files: {
-        //  root: path.join(directory, this.config.paths.files.root)
-        //}
       };
 
       // If build path is absolute, do not prepend the project directory.
@@ -137,42 +120,34 @@ class Project {
         return;
       }
 
-      // Create root, modules, builds, themes, and files folders.
+      // Create Aquifer directories.
       fs.mkdirSync(this.directory);
-      fs.mkdirSync(this.absolutePaths.build);
-      fs.mkdirSync(this.absolutePaths.settings);
-      fs.mkdirSync(this.absolutePaths.root);
-      fs.mkdirSync(this.absolutePaths.drush);
-      fs.mkdirSync(this.absolutePaths.themes.root);
-      fs.mkdirSync(this.absolutePaths.themes.custom);
-      fs.mkdirSync(this.absolutePaths.modules.root);
-      fs.mkdirSync(this.absolutePaths.modules.custom);
-      fs.mkdirSync(this.absolutePaths.modules.features);
-      fs.mkdirSync(this.absolutePaths.files.root);
       fs.mkdirSync(path.join(this.directory, '.aquifer'));
-
-      // .gitkeeps in module, theme, and build folders
-      touch.sync(path.join(this.absolutePaths.modules.custom, '.gitkeep'));
-      touch.sync(path.join(this.absolutePaths.modules.features, '.gitkeep'));
-      touch.sync(path.join(this.absolutePaths.themes.root, '.gitkeep'));
-      touch.sync(path.join(this.absolutePaths.themes.custom, '.gitkeep'));
+      fs.mkdirSync(this.absolutePaths.build);
       touch.sync(path.join(this.absolutePaths.build, '.gitkeep'));
-      touch.sync(path.join(this.absolutePaths.settings, '.gitkeep'));
-      touch.sync(path.join(this.absolutePaths.root, '.gitkeep'));
-      touch.sync(path.join(this.absolutePaths.files.root, '.gitkeep'));
 
-      // Copy over src files.
-      fs.copySync(path.join(this.srcDir, 'default.settings.php'), path.join(this.absolutePaths.settings, 'settings.php'));
-      fs.copySync(path.join(this.srcDir, 'default.secret.settings.php'), path.join(this.absolutePaths.settings, 'secret.settings.php'));
-      fs.copySync(path.join(this.srcDir, 'default.local.settings.php'), path.join(this.absolutePaths.settings, 'local.settings.php'));
+      // Create Drupal sync directories.
+      Object.keys(this.config.sync.directories).forEach((key) => {
+        let data = this.config.sync.directories[key];
+        // Create directory.
+        fs.mkdirsSync(path.join(this.directory, key));
+        // Add .gitkeep.
+        touch.sync(path.join(this.directory, key, '.gitkeep'));
+      });
+
+      // Copy over Aquifer src files.
       fs.copySync(path.join(this.srcDir, 'drupal.make.yml'), this.absolutePaths.make);
-      fs.copySync(path.join(this.srcDir, 'drushrc.php'), path.join(this.absolutePaths.drush, 'drushrc.php'));
       fs.copySync(path.join(this.srcDir, 'editorconfig'), path.join(this.directory, '.editorconfig'));
       fs.copySync(path.join(this.srcDir, 'gitignore'), path.join(this.directory, '.gitignore'));
       fs.copySync(path.join(this.srcDir, 'package.json'), path.join(this.directory, '.aquifer/package.json'));
-      fs.copySync(path.join(this.srcDir, 'root.htaccess'), path.join(this.absolutePaths.root, '.htaccess'));
-      fs.copySync(path.join(this.srcDir, 'robots.txt'), path.join(this.absolutePaths.root, 'robots.txt'));
-      fs.copySync(path.join(this.srcDir, 'files.htaccess'), path.join(this.absolutePaths.files.root, '.htaccess'));
+
+      // Copy over Drupal src files.
+      fs.copySync(path.join(this.srcDir, 'root.htaccess'), path.join(this.directory, 'root/.htaccess'));
+      fs.copySync(path.join(this.srcDir, 'robots.txt'), path.join(this.directory, 'root/robots.txt'));
+      fs.copySync(path.join(this.srcDir, 'default.settings.php'), path.join(this.directory, 'settings/settings.php'));
+      fs.copySync(path.join(this.srcDir, 'default.secret.settings.php'), path.join(this.directory, 'settings/secret.settings.php'));
+      fs.copySync(path.join(this.srcDir, 'default.local.settings.php'), path.join(this.directory, 'settings/local.settings.php'));
+      fs.copySync(path.join(this.srcDir, 'files.htaccess'), path.join(this.directory, 'files/.htaccess'));
 
       // Create aquifer.json file.
       jsonFile.writeFileSync(this.absolutePaths.json, this.config);

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -97,23 +97,23 @@ class Project {
         json: jsonPath,
         make: path.join(directory, this.config.paths.make),
         settings: path.join(directory, this.config.paths.settings),
-        root: path.join(directory, this.config.paths.root),
+        //root: path.join(directory, this.config.paths.root),
         drush: path.join(directory, this.config.paths.drush),
         build: path.join(directory, this.config.paths.build),
-        themes: {
-          root: path.join(directory, this.config.paths.themes.root),
-          contrib: path.join(directory, this.config.paths.themes.contrib),
-          custom: path.join(directory, this.config.paths.themes.custom)
-        },
-        modules: {
-          root: path.join(directory, this.config.paths.modules.root),
-          contrib: path.join(directory, this.config.paths.modules.contrib),
-          custom: path.join(directory, this.config.paths.modules.custom),
-          features: path.join(directory, this.config.paths.modules.features)
-        },
-        files: {
-          root: path.join(directory, this.config.paths.files.root)
-        }
+        //themes: {
+        //  root: path.join(directory, this.config.paths.themes.root),
+        //  contrib: path.join(directory, this.config.paths.themes.contrib),
+        //  custom: path.join(directory, this.config.paths.themes.custom)
+        //},
+        //modules: {
+        //  root: path.join(directory, this.config.paths.modules.root),
+        //  contrib: path.join(directory, this.config.paths.modules.contrib),
+        //  custom: path.join(directory, this.config.paths.modules.custom),
+        //  features: path.join(directory, this.config.paths.modules.features)
+        //},
+        //files: {
+        //  root: path.join(directory, this.config.paths.files.root)
+        //}
       };
 
       // If build path is absolute, do not prepend the project directory.

--- a/src/d7/aquifer.default.json
+++ b/src/d7/aquifer.default.json
@@ -3,23 +3,57 @@
   "core": 7,
   "paths": {
     "make": "drupal.make.yml",
-    "settings": "settings",
-    "build": "build",
-    "root": "root",
-    "drush": "drush",
-    "themes": {
-      "root": "themes",
-      "contrib": "themes/contrib",
-      "custom": "themes/custom"
-    },
-    "modules": {
-      "root": "modules",
-      "contrib": "modules/contrib",
-      "custom": "modules/custom",
-      "features": "modules/features"
+    "build": "build"
+  },
+  "sync": {
+    "directories": {
+      "modules/custom": {
+        "destination": "sites/all/modules/custom",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "modules/features": {
+        "destination": "sites/all/modules/features",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "themes/custom": {
+        "destination": "themes/custom",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "files": {
+        "destination": "sites/default/files",
+        "method": "symlink",
+        "conflict": "overwrite"
+      }
     },
     "files": {
-      "root": "files"
+      "root/.htaccess": {
+        "destination": ".htaccess",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "root/robots.txt": {
+        "destination": "robots.txt",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "settings/settings.php": {
+        "destination": "sites/default/settings.php",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "settings/secret.settings.php": {
+        "destination": "sites/default/secret.settings.php",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "settings/local.settings.php": {
+        "destination": "sites/default/local.settings.php",
+        "method": "symlink",
+        "conflict": "overwrite"
+      }
     }
   },
   "run": {

--- a/src/d7/aquifer.default.json
+++ b/src/d7/aquifer.default.json
@@ -7,6 +7,11 @@
   },
   "sync": {
     "directories": {
+      "root": {
+        "destination": "",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
       "modules/custom": {
         "destination": "sites/all/modules/custom",
         "method": "symlink",
@@ -29,16 +34,6 @@
       }
     },
     "files": {
-      "root/.htaccess": {
-        "destination": ".htaccess",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "root/robots.txt": {
-        "destination": "robots.txt",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
       "settings/settings.php": {
         "destination": "sites/default/settings.php",
         "method": "symlink",

--- a/src/d8/aquifer.default.json
+++ b/src/d8/aquifer.default.json
@@ -3,24 +3,52 @@
   "core": 8,
   "paths": {
     "make": "drupal.make.yml",
-    "lock": false,
-    "settings": "settings",
-    "build": "build",
-    "root": "root",
-    "drush": "drush",
-    "themes": {
-      "root": "themes",
-      "contrib": "themes/contrib",
-      "custom": "themes/custom"
-    },
-    "modules": {
-      "root": "modules",
-      "contrib": "modules/contrib",
-      "custom": "modules/custom",
-      "features": "modules/features"
+    "build": "build"
+  },
+  "sync": {
+    "directories": {
+      "modules/custom": {
+        "destination": "modules/custom",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "themes/custom": {
+        "destination": "themes/custom",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "files": {
+        "destination": "sites/default/files",
+        "method": "symlink",
+        "conflict": "overwrite"
+      }
     },
     "files": {
-      "root": "files"
+      "root/.htaccess": {
+        "destination": ".htaccess",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "root/robots.txt": {
+        "destination": "robots.txt",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "settings/settings.php": {
+        "destination": "sites/default/settings.php",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "settings/secret.settings.php": {
+        "destination": "sites/default/secret.settings.php",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "settings/local.settings.php": {
+        "destination": "sites/default/local.settings.php",
+        "method": "symlink",
+        "conflict": "overwrite"
+      }
     }
   },
   "run": {

--- a/src/d8/aquifer.default.json
+++ b/src/d8/aquifer.default.json
@@ -7,6 +7,11 @@
   },
   "sync": {
     "directories": {
+      "root": {
+        "destination": "",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
       "modules/custom": {
         "destination": "modules/custom",
         "method": "symlink",
@@ -24,16 +29,6 @@
       }
     },
     "files": {
-      "root/.htaccess": {
-        "destination": ".htaccess",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "root/robots.txt": {
-        "destination": "robots.txt",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
       "settings/settings.php": {
         "destination": "sites/default/settings.php",
         "method": "symlink",


### PR DESCRIPTION
Adds less opinionated configuration for directories and files that get synced into the build. These are now configured in `aquifer.json` in the `sync.directories` and `sync.files` objects respectively. Also decisions can be made per directory or file how items should be synced (symlinked or copied) and how conflicts should be handled (overwrite or skip). As usual, "sensible defaults" are provided.

**To test:**
- Run `aquifer create test -d 8`
- `cd test`
- Run `aquifer build`
- Verify that the `/build` directory contains a Drupal site and the synced directories and files defined in `aquifer.json` are synced appropriately.
- Run `mkdir -p config/base`
- Add the following to the `sync.directories` object in `aquifer.json`:

```
"config": {
  "destination": "sites/default/config",
  "method": "symlink",
  "conflict": "overwrite"
}
```
- Run `aquifer build` and verify the new `/config` directory is symlinked into `/build/sites/default`.
- Run `touch root/LICENSE.txt`
- Add the following to the `sync.files` object in `aquifer.json`:

```
"root/LICENSE.txt": {
  "destination": "LICENSE.txt",
  "method": "copy",
  "conflict": "overwrite"
}
```
- Run `aquifer build` and verify `/build/LICENSE.txt` is overwritten by a copy (not symlink) or your blank file.
- In `aquifer.json` change the conflict value to skip for `root/LICENSE.txt`.
- Run `aquifer build` and verify `/build/LICENSE.txt` is has been left alone.
