### PR TITLE
Composer aquifer-git compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Edit the `aquifer.json` file in your project root and change the `build` object 
 "build": {
   "method": "composer",
   "directory": "build",
-  "makeFile": "composer.json"
+  "makeFile": "composer.json",
+  "scriptsDir": "scripts/composer"
 }
 ```
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -1,4 +1,23 @@
-## New aquifer.json directory configuration
+## [2016-06-02] Run `composer install` inside build directory
+
+Performs Composer build by copying `composer.json`, `composer.lock`, and `/scripts/composer` into the build directory and runs `composer install` from withing the build directory.
+
+This makes `aquifer build` using composer more flexible and able to work with alternative build directories such as those creates bu `aquifer-git`.
+
+This will break projects that have the build directory prepended to their `vendor-dir` and `installer-paths` settings in `composer.json`. Those settings should be reconfigured to be relative to the project build directory.
+
+You will also need to add the add a `build.scriptsDir` property to your `aquifer.json` file:
+
+```
+"build": {
+  "method": "composer",
+  "directory": "build",
+  "makeFile": "composer.json",
+  "scriptsDir": "scripts/composer"
+}
+```
+
+## [2016-05-17] New aquifer.json directory configuration
 
 The configuration for Drupal directories in `aquifer.json` has changed.
 

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -105,7 +105,6 @@ class Build {
 
       let command = '';
       let commandOptions = {};
-      let afterBuild = () => {};
 
       // In the future defer to a "build plugin" to run the command needed.
       if (this.options.buildMethod === 'drush make') {
@@ -117,9 +116,6 @@ class Build {
         // then this is probably getting run by aquifer git.
         if (destination !== project.config.build.directory) {
           let buildDir = path.join(project.directory, destination);
-          // Set environment variables for use in composer scripts.
-          process.env['AQUIFER_PROJECT_ROOT'] = project.directory;
-          process.env['AQUIFER_DRUPAL_ROOT'] = destination;
 
           // Copy composer files to the build directory.
           fs.copySync(path.join(project.directory, 'composer.json'), path.join(buildDir, 'composer.json'));
@@ -137,13 +133,6 @@ class Build {
 
           // Run composer install inside the build directory.
           command = 'bash -c "cd ' + buildDir + ' && composer install"';
-
-          // Tasks to execute after build completes.
-          afterBuild = () => {
-            // Delete environment variables.
-            delete process.env['AQUIFER_PROJECT_ROOT'];
-            delete process.env['AQUIFER_DRUPAL_ROOT'];
-          };
         }
         else {
           command = 'composer install -d ' + path.dirname(this.options.makeFile);
@@ -154,10 +143,6 @@ class Build {
       // Run build command.
       this.aquifer.console.log('Executing ' + this.options.buildMethod + '...');
       run.invoke(command, commandOptions)
-      .then(() => {
-        // Run after build tasks.
-        afterBuild();
-
         // Copy or symlink custom code files and directories.
         this.aquifer.console.log(this.options.symlink ? 'Creating symlinks...' : 'Copying files and directories...');
         let links = [];

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -101,6 +101,7 @@ class Build {
 
       let command = '';
       let commandOptions = {};
+      let afterBuild = () => {};
 
       // In the future defer to a "build plugin" to run the command needed.
       if (this.options.buildMethod === 'drush make') {
@@ -108,6 +109,39 @@ class Build {
         commandOptions = {cwd: this.destination};
       }
       else if (this.options.buildMethod === 'composer') {
+        // If the destination is different that our config build directory value
+        // then this is probably getting run by aquifer git.
+        if (destination !== project.config.build.directory) {
+          // If composer.json.bak file exists then we may have had a failed or
+          // aborted build. Have user verify their config.
+          if (fs.existsSync(path.join(project.directory, 'composer.json.bak'))) {
+            reject('You have a composer.json.bak file in your project root. This probably indicates a previously failed or aborted build. Please verify the contents of composer.json and replace it with composer.json.bak or delete composer.json.bak.');
+          }
+
+          // Set an environment variable for use in composer scripts.
+          process.env['AQUIFER_DRUPAL_ROOT'] = destination;
+          // Make a backup copy of composer.json.
+          fs.copySync(path.join(project.directory, 'composer.json'), path.join(project.directory, 'composer.json.bak'));
+
+          // Replace the build directory strings in composer.json. Kinda janky.
+          replace({
+            regex: '"' + project.config.build.directory + '/',
+            replacement: '"' + destination + '/',
+            paths: [path.join(project.directory, 'composer.json')],
+            recursive: false,
+            silent: true
+          });
+
+          // Tasks to execute after build completes.
+          afterBuild = () => {
+            // Delete environment variable.
+            delete process.env['AQUIFER_DRUPAL_ROOT'];
+            // Restore composer.json from backup.
+            fs.removeSync(path.join(project.directory, 'composer.json'));
+            fs.renameSync(path.join(project.directory, 'composer.json.bak'), path.join(project.directory, 'composer.json'));
+          };
+        }
+
         command = 'composer install -d ' + path.dirname(this.options.makeFile);
         commandOptions = {cwd: this.destination};
       }
@@ -116,6 +150,9 @@ class Build {
       this.aquifer.console.log('Executing ' + this.options.buildMethod + '...');
       run.invoke(command, commandOptions)
       .then(() => {
+        // Run after build tasks.
+        afterBuild();
+
         // Copy or symlink custom code files and directories.
         this.aquifer.console.log(this.options.symlink ? 'Creating symlinks...' : 'Copying files and directories...');
         let links = [];

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -112,38 +112,39 @@ class Build {
         // If the destination is different that our config build directory value
         // then this is probably getting run by aquifer git.
         if (destination !== project.config.build.directory) {
-          // If composer.json.bak file exists then we may have had a failed or
-          // aborted build. Have user verify their config.
-          if (fs.existsSync(path.join(project.directory, 'composer.json.bak'))) {
-            reject('You have a composer.json.bak file in your project root. This probably indicates a previously failed or aborted build. Please verify the contents of composer.json and replace it with composer.json.bak or delete composer.json.bak.');
-          }
-
-          // Set an environment variable for use in composer scripts.
+          let buildDir = path.join(project.directory, destination);
+          // Set environment variables for use in composer scripts.
+          process.env['AQUIFER_PROJECT_ROOT'] = project.directory;
           process.env['AQUIFER_DRUPAL_ROOT'] = destination;
-          // Make a backup copy of composer.json.
-          fs.copySync(path.join(project.directory, 'composer.json'), path.join(project.directory, 'composer.json.bak'));
+
+          // Copy composer files to the build directory.
+          fs.copySync(path.join(project.directory, 'composer.json'), path.join(buildDir, 'composer.json'));
+          fs.copySync(path.join(project.directory, 'composer.lock'), path.join(buildDir, 'composer.lock'));
+          fs.copySync(path.join(project.directory, 'scripts'), path.join(buildDir, 'scripts'));
 
           // Replace the build directory strings in composer.json. Kinda janky.
           replace({
             regex: '"' + project.config.build.directory + '/',
-            replacement: '"' + destination + '/',
-            paths: [path.join(project.directory, 'composer.json')],
+            replacement: '"',
+            paths: [path.join(buildDir, 'composer.json')],
             recursive: false,
             silent: true
           });
 
+          // Run composer install inside the build directory.
+          command = 'bash -c "cd ' + buildDir + ' && composer install"';
+
           // Tasks to execute after build completes.
           afterBuild = () => {
-            // Delete environment variable.
+            // Delete environment variables.
+            delete process.env['AQUIFER_PROJECT_ROOT'];
             delete process.env['AQUIFER_DRUPAL_ROOT'];
-            // Restore composer.json from backup.
-            fs.removeSync(path.join(project.directory, 'composer.json'));
-            fs.renameSync(path.join(project.directory, 'composer.json.bak'), path.join(project.directory, 'composer.json'));
           };
         }
-
-        command = 'composer install -d ' + path.dirname(this.options.makeFile);
-        commandOptions = {cwd: this.destination};
+        else {
+          command = 'composer install -d ' + path.dirname(this.options.makeFile);
+          commandOptions = {cwd: this.destination};
+        }
       }
 
       // Run build command.

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -10,7 +10,6 @@ const _ = require('lodash');
 const fs = require('fs-extra');
 const del = require('del');
 const path = require('path');
-const replace = require('replace');
 
 /**
  * Constructs build API for Aquifer.
@@ -112,32 +111,45 @@ class Build {
         commandOptions = {cwd: this.destination};
       }
       else if (this.options.buildMethod === 'composer') {
-        // If the destination is different that our config build directory value
-        // then this is probably getting run by aquifer git.
-        if (destination !== project.config.build.directory) {
-          let buildDir = path.join(project.directory, destination);
+        let buildDir = path.join(project.directory, destination);
+        let composerAssetsSymlink = this.options.symlink;
+        // Define composer assets that need to get symlinked/copied into the
+        // build.
+        let composerAssets = {
+          'composer.json': 'file',
+          'composer.lock': 'file'
+        };
 
-          // Copy composer files to the build directory.
-          fs.copySync(path.join(project.directory, 'composer.json'), path.join(buildDir, 'composer.json'));
-          fs.copySync(path.join(project.directory, 'composer.lock'), path.join(buildDir, 'composer.lock'));
-          fs.copySync(path.join(project.directory, 'scripts'), path.join(buildDir, 'scripts'));
-
-          // Replace the build directory strings in composer.json. Kinda janky.
-          replace({
-            regex: '"' + project.config.build.directory + '/',
-            replacement: '"',
-            paths: [path.join(buildDir, 'composer.json')],
-            recursive: false,
-            silent: true
-          });
-
-          // Run composer install inside the build directory.
-          command = 'bash -c "cd ' + buildDir + ' && composer install"';
+        // Add the build scripts directory if it's defined in aquifer.json.
+        if (project.config.build.scriptsDir) {
+          composerAssets[project.config.build.scriptsDir] = 'dir';
         }
-        else {
-          command = 'composer install -d ' + path.dirname(this.options.makeFile);
-          commandOptions = {cwd: this.destination};
-        }
+
+        // Iterate over composer assets and symlink/copy them into the build.
+        _.forIn(composerAssets, function(composerAssetType, composerAsset) {
+          let composerAssetPath = path.join(project.directory, composerAsset);
+
+          if (fs.existsSync(composerAssetPath)) {
+            let composerAssetDest = path.join(buildDir, composerAsset);
+            let composerAssetDestDir = path.dirname(composerAssetDest);
+
+            if (!fs.existsSync(composerAssetDestDir)) {
+              fs.mkdirsSync(composerAssetDestDir);
+            }
+
+            if (!composerAssetsSymlink) {
+              // Copy composer asset into the build directory.
+              fs.copySync(composerAssetPath, path.join(buildDir, composerAsset));
+            }
+            else {
+              // Symlink composer asset into the build directory.
+              fs.symlinkSync(composerAssetPath, path.join(buildDir, composerAsset), composerAssetType);
+            }
+          }
+        });
+
+        // Run composer install inside the build directory.
+        command = 'bash -c "cd ' + buildDir + ' && composer install"';
       }
 
       // Run build command.

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -112,7 +112,6 @@ class Build {
       }
       else if (this.options.buildMethod === 'composer') {
         let buildDir = path.join(project.directory, destination);
-        let composerAssetsSymlink = this.options.symlink;
         // Define composer assets that need to get symlinked/copied into the
         // build.
         let composerAssets = {
@@ -137,14 +136,8 @@ class Build {
               fs.mkdirsSync(composerAssetDestDir);
             }
 
-            if (!composerAssetsSymlink) {
-              // Copy composer asset into the build directory.
-              fs.copySync(composerAssetPath, path.join(buildDir, composerAsset));
-            }
-            else {
-              // Symlink composer asset into the build directory.
-              fs.symlinkSync(composerAssetPath, path.join(buildDir, composerAsset), composerAssetType);
-            }
+            // Copy composer asset into the build directory.
+            fs.copySync(composerAssetPath, path.join(buildDir, composerAsset));
           }
         });
 

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -112,32 +112,54 @@ class Build {
       }
       else if (this.options.buildMethod === 'composer') {
         let buildDir = path.join(project.directory, destination);
+        let composerSymlink = this.options.symlink;
         // Define composer assets that need to get symlinked/copied into the
-        // build.
+        // build. Drupal does not work if composer.json is symlinked.
         let composerAssets = {
-          'composer.json': 'file',
-          'composer.lock': 'file'
+          'composer.json': {
+            type: 'file',
+            method: 'copy'
+          },
+          'composer.lock': {
+            type: 'file',
+            method: 'copy'
+          }
         };
 
         // Add the build scripts directory if it's defined in aquifer.json.
         if (project.config.build.scriptsDir) {
-          composerAssets[project.config.build.scriptsDir] = 'dir';
+          composerAssets[project.config.build.scriptsDir] = {
+            type: 'dir',
+            method: 'symlink'
+          };
         }
 
         // Iterate over composer assets and symlink/copy them into the build.
-        _.forIn(composerAssets, function(composerAssetType, composerAsset) {
+        _.forIn(composerAssets, function(composerAssetData, composerAsset) {
           let composerAssetPath = path.join(project.directory, composerAsset);
 
           if (fs.existsSync(composerAssetPath)) {
             let composerAssetDest = path.join(buildDir, composerAsset);
             let composerAssetDestDir = path.dirname(composerAssetDest);
 
+            // Delete destination if it exists.
+            if (fs.existsSync(composerAssetDest)) {
+              del.sync(composerAssetDest);
+            }
+
+            // Create base directory if it doesn't exist.
             if (!fs.existsSync(composerAssetDestDir)) {
               fs.mkdirsSync(composerAssetDestDir);
             }
 
-            // Copy composer asset into the build directory.
-            fs.copySync(composerAssetPath, path.join(buildDir, composerAsset));
+            if (!composerSymlink || composerAssetData.method === 'copy') {
+              // Copy composer asset into the build directory.
+              fs.copySync(composerAssetPath, composerAssetDest);
+            }
+            else {
+              // Copy composer asset into the build directory.
+              fs.symlinkSync(composerAssetPath, composerAssetDest, composerAssetData.type);
+            }
           }
         });
 

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -143,6 +143,7 @@ class Build {
       // Run build command.
       this.aquifer.console.log('Executing ' + this.options.buildMethod + '...');
       run.invoke(command, commandOptions)
+      .then(() => {
         // Copy or symlink custom code files and directories.
         this.aquifer.console.log(this.options.symlink ? 'Creating symlinks...' : 'Copying files and directories...');
         let links = [];

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "lodash": "^3.6.0",
     "parse-spawn-args": "^1.0.2",
     "path": "^0.11.14",
-    "replace": "^0.3.0",
     "ssh2": "^0.4.13",
     "touch": "0.0.3",
     "untildify": "^2.1.0"

--- a/src/d8/scripts/composer/ScriptHandler.php
+++ b/src/d8/scripts/composer/ScriptHandler.php
@@ -13,11 +13,24 @@ use Symfony\Component\Filesystem\Filesystem;
 class ScriptHandler {
 
   protected static function getDrupalRoot($project_root) {
-    // Get config from aquifer.json.
-    $json = file_get_contents($project_root . '/aquifer.json');
-    $json_array = json_decode($json, TRUE);
+    $fs = new Filesystem();
 
+    // Allow environment variable to override project root.
+    if (getenv('AQUIFER_PROJECT_ROOT')) {
+      $project_root = getenv('AQUIFER_PROJECT_ROOT');
+    }
+
+    // Allow environment variable to override Drupal root.
     if (!$drupal_root = getenv('AQUIFER_DRUPAL_ROOT')) {
+      $json_array = FALSE;
+
+      // Get build directory from aquifer.json.
+      if ($fs->exists($project_root . '/aquifer.json')) {
+        // Get config from aquifer.json.
+        $json = file_get_contents($project_root . '/aquifer.json');
+        $json_array = json_decode($json, TRUE);
+      }
+
       if (!empty($json_array)
         && isset($json_array['build'])
         && isset($json_array['build']['directory'])) {


### PR DESCRIPTION
Adds support for building to a temporary directory (e.g. when running `aquifer deploy-git`) using Aquifer's composer build. 

Performs Composer build by copying `composer.json`, `composer.lock`, and `/scripts/composer` into the build directory and runs `composer install` from withing the build directory.

This makes `aquifer build` using composer more flexible and able to work with alternative build directories such as those creates bu `aquifer-git`.

This will break projects that have the build directory prepended to their `vendor-dir` and `installer-paths` settings in `composer.json`. Those settings should be reconfigured to be relative to the project build directory.

You will also need to add the add a `build.scriptsDir` property to your `aquifer.json` file:

```
"build": {
  "method": "composer",
  "directory": "build",
  "makeFile": "composer.json",
  "scriptsDir": "scripts/composer"
}
```

**To test:**
- Create a D8 site by running `aquifer create test -d 8 && cd test`
- Edit the `aquifer.json` file changing the `build` object properties to look like so:
  
  ```
  "build": {
    "method": "composer",
    "directory": "build",
    "makeFile": "composer.json",
    "scriptsDir": "scripts/composer"
  }
  ```
- Note you will likely need to run the 1.0.0 version of aquifer-git to test this successfully. Add the following to `.aquifer/package.json`:
  
  ```
  "dependencies": {
    "aquifer-git": "aquifer/aquifer-git#1.0.0"
  }
  ```
- Run `aquifer extensions-load`
- You will need to have a test depository to deploy to and configure `aquifer-git` accordingly in `aquifer.json`. See [aquifer-git docs](https://github.com/aquifer/aquifer-git/tree/1.0.0).
- Run `aquifer deploy-git`
- Ensure command runs without errors and deploys to your repo.
