### PR TITLE
Add post-build command handling

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -236,6 +236,16 @@ class Build {
         })
       })
 
+      // Run post-build commands.
+      .then(() => {
+        let postBuildCommands = project.config.run.postBuild;
+
+        if (postBuildCommands && postBuildCommands.length) {
+          this.aquifer.console.log('Running post-build commands...', 'status');
+          return run.invokeAll(project.config.run.postBuild);
+        }
+      })
+
       // Resolve on finish, or reject if there's a problem.
       .catch((reason) => {
         reject(reason);

--- a/src/d7/aquifer.default.json
+++ b/src/d7/aquifer.default.json
@@ -33,7 +33,8 @@
         "drush fra -y",
         "drush cc drush"
       ]
-    }
+    },
+    "postBuild": []
   },
   "extensions": {},
   "environments": {

--- a/src/d8/aquifer.default.json
+++ b/src/d8/aquifer.default.json
@@ -29,7 +29,8 @@
         "drush updb -y",
         "drush cr -y"
       ]
-    }
+    },
+    "postBuild": []
   },
   "extensions": {}
 }


### PR DESCRIPTION
Allows post-build commands to be configured in aquifer.json.

**To test:**
- Run `aquifer create test -d 8 && cd test`
- Edit aquifer.json and add a command to to `run.postBuild` e.g.:
  
  ```
  "run": {
    "scripts": {
      "refresh": [
        "drush updb -y",
        "drush cr -y"
      ]
    },
    "postBuild": [
      "drush cc all"
    ]
  }
  ```
- Run `aquifer build`
- You should see evidence of `drush cc all` attempting to run at the end:
  ![aquifer_json_-_nyunursing_-____sites_nyunursing_](https://cloud.githubusercontent.com/assets/2602202/15378275/2f76520c-1d1f-11e6-80f9-0edf0b248189.png)
