### PR TITLE
(node:30413) fs: re-evaluating native module sources is not supported. If you are using the graceful-fs module, please update it to a more recent version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "chalk": "^1.0.0",
     "commander": "^2.7.1",
     "del": "^1.2.1",
-    "fs-extra": "^0.18.0",
+    "fs-extra": "^0.30.0",
     "inquirer": "^0.11.4",
     "jsonfile": "^2.0.0",
     "lodash": "^3.6.0",


### PR DESCRIPTION
Fixes #132 by updating fs-extra to v0.30.0.
