### PR TITLE
Use the correct theme directory for d7.

### DIFF
--- a/src/d7/aquifer.default.json
+++ b/src/d7/aquifer.default.json
@@ -24,7 +24,7 @@
         "conflict": "overwrite"
       },
       "themes/custom": {
-        "destination": "themes/custom",
+        "destination": "sites/all/themes/custom",
         "method": "symlink",
         "conflict": "overwrite"
       },


### PR DESCRIPTION
This looks like it was some copy pasta from the d8 aquifer.default.json. It caused custom themes to be placed in the wrong place in d7 builds.
