### PR TITLE
Allow the aquifer.json settings to change the drupal.make.yml file name

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -69,7 +69,7 @@ class Build {
       let project = this.aquifer.project;
 
       // Set some reasonable defaults.
-      this.options.makeFile = project.absolutePaths.make ? project.absolutePaths.make : this.getAbsolutePath('drupal.make.yml') ;
+      this.options.makeFile = project.absolutePaths.make;
       this.options.buildMethod = this.options.buildMethod || project.config.build.method;
 
       // Make sure the make file exists.

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -32,7 +32,8 @@ class Build {
       symlink: true,
       delPatterns: ['*', '.*'],
       excludeLinks: [],
-      addLinks: []
+      addLinks: [],
+      makeFile: this.getAbsolutePath('drupal.make.yml')
     }
   }
 
@@ -69,7 +70,7 @@ class Build {
       let project = this.aquifer.project;
 
       // Set some reasonable defaults.
-      this.options.makeFile = project.absolutePaths.make;
+      this.options.makeFile = this.getAbsolutePath(this.options.makeFile) || project.absolutePaths.makeFile;
       this.options.buildMethod = this.options.buildMethod || project.config.build.method;
 
       // Make sure the make file exists.

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -32,8 +32,7 @@ class Build {
       symlink: true,
       delPatterns: ['*', '.*'],
       excludeLinks: [],
-      addLinks: [],
-      makeFile: this.getAbsolutePath('drupal.make.yml')
+      addLinks: []
     }
   }
 
@@ -70,7 +69,7 @@ class Build {
       let project = this.aquifer.project;
 
       // Set some reasonable defaults.
-      this.options.makeFile = this.getAbsolutePath(this.options.makeFile) || project.absolutePaths.makeFile;
+      this.options.makeFile = project.absolutePaths.make ? project.absolutePaths.make : this.getAbsolutePath('drupal.make.yml') ;
       this.options.buildMethod = this.options.buildMethod || project.config.build.method;
 
       // Make sure the make file exists.

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -32,8 +32,7 @@ class Build {
       symlink: true,
       delPatterns: ['*', '.*'],
       excludeLinks: [],
-      addLinks: [],
-      makeFile: this.getAbsolutePath('drupal.make.yml')
+      addLinks: []
     }
   }
 
@@ -70,7 +69,7 @@ class Build {
       let project = this.aquifer.project;
 
       // Set some reasonable defaults.
-      this.options.makeFile = this.getAbsolutePath(this.options.makeFile) || project.absolutePaths.makeFile;
+      this.options.makeFile = project.absolutePaths.make;
       this.options.buildMethod = this.options.buildMethod || project.config.build.method;
 
       // Make sure the make file exists.


### PR DESCRIPTION
## Purpose:
- Bug fix for aquifer.json drush make settings
## Recreate:
- Change the file name of drupal.make.yml to drupal.make
- Change the aquifer.json makeFile setting to drupal.make
- Attempt to build and notice errors
## Notes:
- It appears that somewhere along the way we hard coded "drupal.make.yml" into the build.api.js file
- If the name was changed then the function getAbsolutePath failed with errors
- We also referenced project.absolutePaths.makeFile instead of .make
## Reproduce steps:

Using the latest commit on 1.0.0 (b052151) and changing the drupal.make.yml setting and filename to drupal.make, the run `aquifer build` and watch it return:

```
aquifer build
{ [Error: ENOENT: no such file or directory, stat '/Users/developer/vms/aquifer/drupal.make.yml']
  errno: -2,
  code: 'ENOENT',
  syscall: 'stat',
  path: '/Users/developer/vms/aquifer/drupal.make.yml' }
```
## UPDATE:

After some further testing.  I originally though the getAbsolutePath function was failing to produce a path but interestingly enough it creates a path for a file that doesn't exist.
