### PR TITLE
Add missing directories to aquifer.default.json

### DIFF
--- a/src/d7/aquifer.default.json
+++ b/src/d7/aquifer.default.json
@@ -13,6 +13,11 @@
         "method": "symlink",
         "conflict": "overwrite"
       },
+      "modules/contrib": {
+        "destination": "sites/all/modules/contrib",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
       "modules/custom": {
         "destination": "sites/all/modules/custom",
         "method": "symlink",
@@ -20,6 +25,11 @@
       },
       "modules/features": {
         "destination": "sites/all/modules/features",
+        "method": "symlink",
+        "conflict": "overwrite"
+      },
+      "themes/contrib": {
+        "destination": "sites/all/themes/contrib",
         "method": "symlink",
         "conflict": "overwrite"
       },


### PR DESCRIPTION
## Purpose:
- Add missing directories to aquifer.default.json
## Notes:
- I am not sure if this was intentional but I noticed in the old aquifer.json config files these directories were included.
