### PR TITLE
Add the ability to use old config files

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -70,7 +70,7 @@ class Build {
       let project = this.aquifer.project;
 
       // Set some reasonable defaults.
-      this.options.makeFile = this.getAbsolutePath(this.options.makeFile) || project.absolutePaths.makeFile;
+      this.options.makeFile = this.getAbsolutePath(this.options.makeFile) || project.absolutePaths.make;
       this.options.buildMethod = this.options.buildMethod || project.config.build.method;
 
       // Make sure the make file exists.

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -95,6 +95,81 @@ class Project {
       this.config.core = this.config.core || this.drupalVersion;
       this.setDrupalVersion(this.config.core);
 
+      // Test and update aquifer.json configuration if necessary.
+      if (typeof this.config.build == 'undefined') {
+        // Configure drush make.
+        this.config.build = {
+          'method': 'drush make',
+          'directory': this.config.paths.build,
+          'makeFile': this.config.paths.make
+        };
+
+        // Root directory transfer.
+        this.config.sync = {
+          'directories': {
+            'root': {
+              'destination': this.config.paths.root,
+              'method': 'symlink',
+              'conflict': 'overwrite'
+            }
+          }
+        };
+
+        // Transfer themes.
+        for (var item in this.config.paths.themes) {
+          if (item == 'root') {
+            // Nothing.
+          }
+          else {
+            this.config.sync.directories[this.config.paths.themes[item]] = {
+              'destination': 'sites/default/' + this.config.paths.themes[item],
+              'method': 'symlink',
+              'conflict': 'overwrite'
+            };
+          }
+        };
+
+        // Transfer modules.
+        for (var item in this.config.paths.modules) {
+          if (item == 'root') {
+            // Nothing.
+          }
+          else {
+            this.config.sync.directories[this.config.paths.modules[item]] = {
+              'destination': 'sites/default/' + this.config.paths.modules[item],
+              'method': 'symlink',
+              'conflict': 'overwrite'
+            };
+          }
+        };
+
+        // Transfer files directory.
+        this.config.sync.directories.files = {
+          'destination': 'sites/default/' + this.config.paths.files.root,
+          'method': 'symlink',
+          'conflict': 'overwrite'
+        }
+
+        // Add individual files.
+        this.config.sync.files = {
+          'settings/settings.php': {
+            'destination': 'sites/default/settings.php',
+            'method': 'symlink',
+            'conflict': 'overwrite'
+          },
+          'settings/secret.settings.php': {
+            'destination': 'sites/default/secret.settings.php',
+            'method': 'symlink',
+            'conflict': 'overwrite'
+          },
+          'settings/local.settings.php': {
+            'destination': 'sites/default/local.settings.php',
+            'method': 'symlink',
+            'conflict': 'overwrite'
+          }
+        }
+      }
+
       // Define absolute paths to assets.
       this.absolutePaths = {
         json: jsonPath,


### PR DESCRIPTION
## Purpose:
- Add the ability to use old config files
## Notes:
- When we upgraded aquifer we left a bunch of "old" projects is the dust.
- This PR reads old config files and transfers the data into the new format during the build process.
- Now my old projects builds shouldn't fail if I don't upgrade the config file.
## Merge conflict:
- This is going to cause a merge conflict with another PR.  The other PR should take priority the changes in build.api.js can be ignored.  They were necessary to make the PR work.
