### PR TITLE
Add ability to force builds outside the aquifer project root

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -192,8 +192,7 @@ class Build {
             switch (link.conflict) {
               case 'overwrite':
                 this.aquifer.console.log('Destination exists. Conflict set to overwrite. \nOverwriting: ' + link.dest, 'status');
-                options.force = true;
-                del.sync(link.dest, options);
+                del.sync(link.dest, {force: true});
                 break;
 
               case 'skip':

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -192,7 +192,7 @@ class Build {
             switch (link.conflict) {
               case 'overwrite':
                 this.aquifer.console.log('Destination exists. Conflict set to overwrite. \nOverwriting: ' + link.dest, 'status');
-                options.force = this.options.force;
+                options.force = true;
                 del.sync(link.dest, options);
                 break;
 

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -192,7 +192,8 @@ class Build {
             switch (link.conflict) {
               case 'overwrite':
                 this.aquifer.console.log('Destination exists. Conflict set to overwrite. \nOverwriting: ' + link.dest, 'status');
-                del.sync(link.dest);
+                options.force = this.options.force;
+                del.sync(link.dest, options);
                 break;
 
               case 'skip':

--- a/lib/build.command.js
+++ b/lib/build.command.js
@@ -17,19 +17,16 @@ module.exports = function (Aquifer) {
   .description('Construct the framework of the site using contents of custom modules, themes, and projects defined in Drush Make.')
   .option('-c, --copy', 'Copy directories instead of creating symlinks.')
   .option('-d, --directory <path>', 'The destination directory in which to build.')
-  .option('-f, --force', 'Allows builds outside the project root.')
   .action((options) => {
     let path = require('path');
     let settings = Aquifer.project.config;
     let copy = options.copy === true;
     let directory = options.directory || settings.build.directory;
     let build = new Aquifer.api.build(Aquifer);
-    let force = options.force;
 
     // Create build.
     build.create(directory, {
-      symlink: !copy,
-      force: force
+      symlink: !copy
     })
     .catch((reason) => {
       Aquifer.console.log(reason, 'error');

--- a/lib/build.command.js
+++ b/lib/build.command.js
@@ -17,16 +17,19 @@ module.exports = function (Aquifer) {
   .description('Construct the framework of the site using contents of custom modules, themes, and projects defined in Drush Make.')
   .option('-c, --copy', 'Copy directories instead of creating symlinks.')
   .option('-d, --directory <path>', 'The destination directory in which to build.')
+  .option('-f, --force', 'Allows builds outside the project root.')
   .action((options) => {
     let path = require('path');
     let settings = Aquifer.project.config;
     let copy = options.copy === true;
     let directory = options.directory || settings.build.directory;
     let build = new Aquifer.api.build(Aquifer);
+    let force = options.force;
 
     // Create build.
     build.create(directory, {
-      symlink: !copy
+      symlink: !copy,
+      force: force
     })
     .catch((reason) => {
       Aquifer.console.log(reason, 'error');


### PR DESCRIPTION
## Purpose:
- Add ability to force builds outside the aquifer project root
## Notes:
- In certain situations, it is desirable to build outside the project root.  The `del` node module allows this but we need a way for aquifer to pass the `--force` option to the module.
## Reproduce:
- `aquifer create test`
- `cd test`
- Edit your aquifer.json file to make the build directory `../build`
- `aquifer build`
## Error:
- Drush make works fine but "overwriting" symlinks doesn't work if the build directory is outside the project root.  I believe this is new with the upgrade of the dependency "fs-extra": "^0.30.0", from "fs-extra": "^0.18.0".  It used to work just fine.

```
Overwriting: /Users/developer/repos/build/.htaccess
[Error: Cannot delete files/folders outside the current working directory. Can be overriden with the `force` option.]
```
- Most people recognize the force command as something potentially dangerous which is why I chose force.
