### PR TITLE
Fix aquifer.json spacing

### DIFF
--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -159,7 +159,7 @@ class Project {
       }
 
       // Create aquifer.json file.
-      jsonFile.writeFileSync(this.absolutePaths.json, this.config);
+      jsonFile.writeFileSync(this.absolutePaths.json, this.config, {spaces: 2});
       resolve();
     })
   }

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -174,7 +174,7 @@ class Project {
     return new Promise((resolve, reject) => {
       if (updateJson) {
         this.config = _.extend(this.config, updateJson);
-        jsonFile.writeFileSync(this.absolutePaths.json, this.config);
+        jsonFile.writeFileSync(this.absolutePaths.json, this.config, {spaces: 2});
       }
 
       resolve();


### PR DESCRIPTION
jsonfile updated and it now allows you to specify spacing rules. If you specify none, it will not space or indent at all. This solves that problem.
## Steps to test
- Checkout this branch.
- Run `aquifer create test`
- Check the aquifer.json file and make sure it's spaced and indented properly.
