### PR TITLE
Add env vars for project and build directories

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -99,6 +99,10 @@ class Build {
       this.aquifer.console.log('Removing possible existing build...');
       del.sync(this.options.delPatterns, { cwd: this.destination });
 
+      // Set environment variables for use in scripts and run commands.
+      process.env['AQUIFER_PROJECT_ROOT'] = project.directory;
+      process.env['AQUIFER_DRUPAL_ROOT'] = destination;
+
       let command = '';
       let commandOptions = {};
 
@@ -237,6 +241,12 @@ class Build {
           this.aquifer.console.log('Running post-build commands...', 'status');
           return run.invokeAll(project.config.run.postBuild);
         }
+      })
+
+      // Clean up environment variables.
+      .then(() => {
+        delete process.env['AQUIFER_PROJECT_ROOT'];
+        delete process.env['AQUIFER_DRUPAL_ROOT'];
       })
 
       // Resolve on finish, or reject if there's a problem.


### PR DESCRIPTION
Sets environment variables for project and drupal build directories that can be used in scripts and run commands.

**To test:**
- Add the following command to the postBuild commands in `aquifer.json`:
  `
  "bash -c \"echo $AQUIFER_DRUPAL_ROOT\""
  `
- Run `aquifer build`
- Ensure the console prints out your build directory name during the postBuild process.
