### PR TITLE
Add ability to run commands prior to syncing files/directories

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -119,6 +119,17 @@ class Build {
       // Run build command.
       this.aquifer.console.log('Executing ' + this.options.buildMethod + '...');
       run.invoke(command, commandOptions)
+      // Run pre-sync commands.
+      .then(() => {
+        let preSyncCommands = project.config.run.preSync;
+
+        if (preSyncCommands && preSyncCommands.length) {
+          this.aquifer.console.log('Running pre-sync commands...', 'status');
+          return run.invokeAll(preSyncCommands);
+        }
+      })
+
+      // Copy or symlink custom code files and directories.
       .then(() => {
         // Copy or symlink custom code files and directories.
         this.aquifer.console.log(this.options.symlink ? 'Creating symlinks...' : 'Copying files and directories...');
@@ -239,7 +250,7 @@ class Build {
 
         if (postBuildCommands && postBuildCommands.length) {
           this.aquifer.console.log('Running post-build commands...', 'status');
-          return run.invokeAll(project.config.run.postBuild);
+          return run.invokeAll(postBuildCommands);
         }
       })
 

--- a/src/d7/aquifer.default.json
+++ b/src/d7/aquifer.default.json
@@ -64,6 +64,7 @@
         "drush cc drush"
       ]
     },
+    "preSync": [],
     "postBuild": []
   },
   "extensions": {},

--- a/src/d8/aquifer.default.json
+++ b/src/d8/aquifer.default.json
@@ -54,6 +54,7 @@
         "drush cr -y"
       ]
     },
+    "preSync": [],
     "postBuild": []
   },
   "extensions": {}


### PR DESCRIPTION
Allows pre-sync commands to be configured in aquifer.json. These commands can be used to manipulate project files and directories prior to their being copied into the build.

**To test:**
- Run `aquifer create test -d 8 && cd test`
- Edit aquifer.json and add a command to to `run.preSync` e.g.:
  
  ```
  "run": {
    "scripts": {
      "refresh": [
        "drush updb -y",
        "drush cr -y"
      ]
    },
    "preSync": [
      "bash -c \"echo 'presync is running'\""
    ],
    "postBuild": []
  }
  ```
- Run `aquifer build`
- You should see evidence of your pre-sync command running prior to syncing files:
  ![aquifer_json_-_nyunursing_-____sites_nyunursing_](https://cloud.githubusercontent.com/assets/2602202/15714219/ee9a8222-27d6-11e6-80cd-bfa4c42166b5.png)
