### PR TITLE
Sync API

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -19,7 +19,8 @@ The new default configuration looks something like this:
       "method": "symlink",
       "conflict": "overwrite",
       "type": "dir",
-      "hook": "postBuild"
+      "hook": "postBuild",
+      "contents": true
     },
     "modules/custom": {
       "destination": "modules/custom",
@@ -42,26 +43,14 @@ The new default configuration looks something like this:
       "type": "dir",
       "hook": "postBuild"
     },
-    "settings/settings.php": {
-      "destination": "sites/default/settings.php",
+    "settings": {
+      "destination": "sites/default",
       "method": "symlink",
       "conflict": "overwrite",
       "type": "file",
-      "hook": "postBuild"
-    },
-    "settings/secret.settings.php": {
-      "destination": "sites/default/secret.settings.php",
-      "method": "symlink",
-      "conflict": "overwrite",
-      "type": "file",
-      "hook": "postBuild"
-    },
-    "settings/local.settings.php": {
-      "destination": "sites/default/local.settings.php",
-      "method": "symlink",
-      "conflict": "overwrite",
-      "type": "file",
-      "hook": "postBuild"
+      "hook": "postBuild",
+      "required": true,
+      "contents": true
     }
   },
   "run": {

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -14,44 +14,54 @@ The new default configuration looks something like this:
     "makeFile": "drupal.make.yml"
   },
   "sync": {
-    "directories": {
-      "root": {
-        "destination": "",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "modules/custom": {
-        "destination": "modules/custom",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "themes/custom": {
-        "destination": "themes/custom",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "files": {
-        "destination": "sites/default/files",
-        "method": "symlink",
-        "conflict": "overwrite"
-      }
+    "root": {
+      "destination": "",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "dir",
+      "hook": "postBuild"
+    },
+    "modules/custom": {
+      "destination": "modules/custom",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "dir",
+      "hook": "preBuild"
+    },
+    "themes/custom": {
+      "destination": "themes/custom",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "dir",
+      "hook": "postBuild"
     },
     "files": {
-      "settings/settings.php": {
-        "destination": "sites/default/settings.php",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "settings/secret.settings.php": {
-        "destination": "sites/default/secret.settings.php",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "settings/local.settings.php": {
-        "destination": "sites/default/local.settings.php",
-        "method": "symlink",
-        "conflict": "overwrite"
-      }
+      "destination": "sites/default/files",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "dir",
+      "hook": "postBuild"
+    },
+    "settings/settings.php": {
+      "destination": "sites/default/settings.php",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "file",
+      "hook": "postBuild"
+    },
+    "settings/secret.settings.php": {
+      "destination": "sites/default/secret.settings.php",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "file",
+      "hook": "postBuild"
+    },
+    "settings/local.settings.php": {
+      "destination": "sites/default/local.settings.php",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "file",
+      "hook": "postBuild"
     }
   },
   "run": {

--- a/bin/aquifer.js
+++ b/bin/aquifer.js
@@ -22,6 +22,7 @@ const Build = require('../lib/build.api');
 const Run = require('../lib/run.api');
 const Extension = require('../lib/extension.api');
 const Environment = require('../lib/environment.api');
+const Sync = require('../lib/sync.api');
 
 AquiferAPI.prototype.console = new Console();
 AquiferAPI.prototype.api = {
@@ -29,7 +30,8 @@ AquiferAPI.prototype.api = {
   build: Build,
   run: Run,
   extension: Extension,
-  environment: Environment
+  environment: Environment,
+  sync: Sync
 }
 
 // Create instance of AquiferAPI.

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -112,7 +112,7 @@ class Build {
         let command = '';
         let commandOptions = {};
 
-        // In the future defer to a "build plugin" to run the command needed.
+        // TODO: Defer to a "build plugin" to run the command needed.
         if (this.options.buildMethod === 'drush make') {
           command = 'drush make -y ' + this.options.makeFile;
           commandOptions = {cwd: this.destination};

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -27,13 +27,14 @@ class Build {
    */
   constructor(Aquifer) {
     this.aquifer = Aquifer;
-    this.destination = this.getAbsolutePath('build');
+    this.project = this.aquifer.project;
+    this.destination = this.project.getAbsolutePath('build');
     this.options = {
       symlink: true,
       delPatterns: ['*', '.*'],
       excludeLinks: [],
       addLinks: [],
-      makeFile: this.getAbsolutePath('drupal.make.yml')
+      makeFile: this.project.getAbsolutePath('drupal.make.yml')
     }
   }
 
@@ -57,13 +58,10 @@ class Build {
     return new Promise((resolve, reject) => {
       let run = new this.aquifer.api.run(this.aquifer);
       let sync = new this.aquifer.api.sync(this.aquifer);
-
-      let items = sync.getBundleItemsMultiple(['directories', 'files']);
-      console.log(items);
-      reject();
+      let project = this.project;
 
       // Set class properties.
-      this.destination = this.getAbsolutePath(destination);
+      this.destination = project.getAbsolutePath(destination);
       if (options) {
         _.assign(this.options, options);
       }
@@ -72,10 +70,10 @@ class Build {
       if (!this.aquifer.initialized) {
         reject('Cannot build a project that hasn\'t been initialized.');
       }
-      let project = this.aquifer.project;
+
 
       // Set some reasonable defaults.
-      this.options.makeFile = this.getAbsolutePath(this.options.makeFile) || project.absolutePaths.makeFile;
+      this.options.makeFile = project.getAbsolutePath(this.options.makeFile) || project.absolutePaths.makeFile;
       this.options.buildMethod = this.options.buildMethod || project.config.build.method;
 
       // Make sure the make file exists.
@@ -127,86 +125,28 @@ class Build {
       .then(() => {
         // Copy or symlink custom code files and directories.
         this.aquifer.console.log(this.options.symlink ? 'Creating symlinks...' : 'Copying files and directories...');
-        let links = [];
-        let project = this.aquifer.project;
-        // We don't need to distinguish between directories and files at this
-        // point so let's combine the config.
-        //let syncItems = _.defaults(project.config.sync.directories, project.config.sync.files);
 
-        //sync.executeBundles(['files', 'directories'], destination, !this.options.symlink);
+        // Handle addLinks option.
+        if (this.options.addLinks.length > 0) {
+          let addItems = {};
 
-        let items = sync.getBundleItemsMultiple(['files', 'directories']);
-        console.log(items);
+          // Provide the structure required by the Sync API.
+          this.options.addLinks.forEach(function(item) {
+            addItems[item.src] = {
+              destination: item.dest
+            }
+          });
 
-        // Add links from options.
-        links = links.concat(this.options.addLinks);
+          sync.addItems(addItems);
+        }
 
-        // Exclude links from options.
-        links = links.filter((link) => {
-          return this.options.excludeLinks.indexOf(link.dest) === -1;
-        });
+        // Handle excludeLinks option.
+        if (this.options.excludeLinks.length > 0) {
+          sync.excludeItems(this.options.excludeLinks);
+        }
 
-        // Create links or copies.
-        //links.forEach((link) => {
-        //  // Log this to the user.
-        //  this.aquifer.console.log(((!this.options.symlink || link.method === 'copy') ? 'Copying ' : 'Symlinking ') + link.src + ' => ' + link.dest)
-        //
-        //  // Make src and dest paths absolute. Determine destination base path.
-        //  link.dest = path.join(this.destination, link.dest);
-        //  link.src = path.join(project.directory, link.src);
-        //  let destBase = path.dirname(link.dest);
-        //  let type = 'file';
-        //
-        //  if (fs.statSync(link.src).isDirectory()) {
-        //    type = 'dir';
-        //  }
-        //
-        //  // If the source doesn't exist, skip this link.
-        //  if (!fs.existsSync(link.src)) {
-        //    this.aquifer.console.log('Source file does not exist. Skipping: ' + link.src, 'status');
-        //    return false;
-        //  }
-        //
-        //  // Handle existing destinations.
-        //  if (fs.existsSync(link.dest)) {
-        //    switch (link.conflict) {
-        //      case 'overwrite':
-        //        this.aquifer.console.log('Destination exists. Conflict set to overwrite. \nOverwriting: ' + link.dest, 'status');
-        //        del.sync(link.dest);
-        //        break;
-        //
-        //      case 'skip':
-        //        this.aquifer.console.log('Destination exists. Conflict set to skip. \nSkipping: ' + link.dest, 'status');
-        //        return false;
-        //
-        //      default:
-        //        return false;
-        //    }
-        //  }
-        //
-        //  // Make sure the destination base path exists.
-        //  if (!fs.existsSync(destBase)) {
-        //    this.aquifer.console.log('Destination directory does not exist. Creating: ' + destBase, 'status');
-        //    fs.mkdirsSync(destBase);
-        //  }
-        //
-        //  // If symlinking is not turned on or the individual link method is
-        //  // copy, copy the item.
-        //  if (!this.options.symlink || link.method === 'copy') {
-        //    fs.copySync(link.src, link.dest);
-        //  }
-        //  // Create symlink
-        //  else {
-        //    // Change current directory to the destination base path (minus last part of path).
-        //    process.chdir(destBase);
-        //
-        //    // Symlink the relative path of the src from the destination into the basename of the path.
-        //    fs.symlinkSync(path.relative(destBase, link.src), path.basename(link.dest), type);
-        //
-        //    // Change the working directory back to the original.
-        //    process.chdir(this.aquifer.cwd);
-        //  }
-        //})
+        // Execute syncing of the directories and files sync bundles.
+        sync.execute(destination, !this.options.symlink, ['directories', 'files']);
       })
 
       // Run post-build commands.
@@ -215,7 +155,7 @@ class Build {
 
         if (postBuildCommands && postBuildCommands.length) {
           this.aquifer.console.log('Running post-build commands...', 'status');
-          return run.invokeAll(project.config.run.postBuild);
+          return run.invokeAll(postBuildCommands);
         }
       })
 
@@ -235,19 +175,6 @@ class Build {
     })
   }
 
-  /**
-   * Returns the absolute path of the given relative path to an asset within an Aquifer project..
-   * @param {string} relativePath relative path to an asset within an Aquifer project.
-   * @returns {string} absolute version of path.
-   */
-  getAbsolutePath(relativePath) {
-    let absolutePath = relativePath;
-    if (path.resolve(relativePath) !== relativePath) {
-      absolutePath = path.join(this.aquifer.project.directory, relativePath);
-    }
-
-    return absolutePath;
-  }
 }
 
 module.exports = Build;

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -105,22 +105,30 @@ class Build {
       process.env['AQUIFER_PROJECT_ROOT'] = project.directory;
       process.env['AQUIFER_DRUPAL_ROOT'] = destination;
 
-      let command = '';
-      let commandOptions = {};
+      // Execute preBuild sync.
+      sync.execute(destination, !this.options.symlink, 'preBuild')
 
-      // In the future defer to a "build plugin" to run the command needed.
-      if (this.options.buildMethod === 'drush make') {
-        command = 'drush make -y ' + this.options.makeFile;
-        commandOptions = {cwd: this.destination};
-      }
-      else if (this.options.buildMethod === 'composer') {
-        command = 'composer install -d ' + path.dirname(this.options.makeFile);
-        commandOptions = {cwd: this.destination};
-      }
+      // Execute build.
+      .then(() => {
+        let command = '';
+        let commandOptions = {};
 
-      // Run build command.
-      this.aquifer.console.log('Executing ' + this.options.buildMethod + '...');
-      run.invoke(command, commandOptions)
+        // In the future defer to a "build plugin" to run the command needed.
+        if (this.options.buildMethod === 'drush make') {
+          command = 'drush make -y ' + this.options.makeFile;
+          commandOptions = {cwd: this.destination};
+        }
+        else if (this.options.buildMethod === 'composer') {
+          command = 'composer install -d ' + path.dirname(this.options.makeFile);
+          commandOptions = {cwd: this.destination};
+        }
+
+        // Run build command.
+        this.aquifer.console.log('Executing ' + this.options.buildMethod + '...');
+        return run.invoke(command, commandOptions);
+      })
+
+      // Execute postBuild sync.
       .then(() => {
         // Copy or symlink custom code files and directories.
         this.aquifer.console.log(this.options.symlink ? 'Creating symlinks...' : 'Copying files and directories...');
@@ -145,8 +153,8 @@ class Build {
           sync.excludeItems(this.options.excludeLinks);
         }
 
-        // Execute syncing of the directories and files sync bundles.
-        return sync.execute(destination, !this.options.symlink, ['directories', 'files']);
+        // Execute postBuild sync.
+        return sync.execute(destination, !this.options.symlink, 'postBuild');
       })
 
       // Run post-build commands.

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -56,6 +56,7 @@ class Build {
   create(destination, options) {
     return new Promise((resolve, reject) => {
       let run = new this.aquifer.api.run(this.aquifer);
+      let sync = new this.aquifer.api.sync(this.aquifer);
 
       // Set class properties.
       this.destination = this.getAbsolutePath(destination);
@@ -126,41 +127,56 @@ class Build {
         let project = this.aquifer.project;
         // We don't need to distinguish between directories and files at this
         // point so let's combine the config.
-        let syncItems = _.defaults(project.config.sync.directories, project.config.sync.files);
+        //let syncItems = _.defaults(project.config.sync.directories, project.config.sync.files);
+
+
+        //
+        sync.executeBundles(['files', 'directories']);
+
+
+        //Object.keys(syncItems).forEach((key) => {
+        //  let item = syncItems[key];
+        //  item.source = key;
+        //  sync.execute(item, destination, !this.options.symlink);
+        //});
+
+
+
+
 
         // Add items to the links array.
-        Object.keys(syncItems).forEach((key) => {
-          // Make sure the source exists in the project.
-          if (fs.existsSync(path.join(project.directory, key))) {
-            let data = syncItems[key];
-
-            // If destination is the Drupal root and the source is a directory
-            // assume we want to copy/sync the contents. Iterate over contents
-            // add them to the links array individually.
-            if (!data.destination && fs.statSync(key).isDirectory()) {
-              fs.readdirSync(path.join(project.directory, key))
-                .filter((item) => {
-                  return item.indexOf('.gitkeep') !== 0;
-                })
-                .forEach((item) => {
-                  links.push({
-                    src: path.join(key, item),
-                    dest: item,
-                    method: data.method,
-                    conflict: data.conflict
-                  });
-                });
-            }
-            else {
-              links.push({
-                src: key,
-                dest: data.destination,
-                method: data.method,
-                conflict: data.conflict
-              });
-            }
-          }
-        });
+        //Object.keys(syncItems).forEach((key) => {
+        //  // Make sure the source exists in the project.
+        //  if (fs.existsSync(path.join(project.directory, key))) {
+        //    let data = syncItems[key];
+        //
+        //    // If destination is the Drupal root and the source is a directory
+        //    // assume we want to copy/sync the contents. Iterate over contents
+        //    // add them to the links array individually.
+        //    if (!data.destination && fs.statSync(key).isDirectory()) {
+        //      fs.readdirSync(path.join(project.directory, key))
+        //        .filter((item) => {
+        //          return item.indexOf('.gitkeep') !== 0;
+        //        })
+        //        .forEach((item) => {
+        //          links.push({
+        //            src: path.join(key, item),
+        //            dest: item,
+        //            method: data.method,
+        //            conflict: data.conflict
+        //          });
+        //        });
+        //    }
+        //    else {
+        //      links.push({
+        //        src: key,
+        //        dest: data.destination,
+        //        method: data.method,
+        //        conflict: data.conflict
+        //      });
+        //    }
+        //  }
+        //});
 
         // Add links from options.
         links = links.concat(this.options.addLinks);
@@ -171,66 +187,66 @@ class Build {
         });
 
         // Create links or copies.
-        links.forEach((link) => {
-          // Log this to the user.
-          this.aquifer.console.log(((!this.options.symlink || link.method === 'copy') ? 'Copying ' : 'Symlinking ') + link.src + ' => ' + link.dest)
-
-          // Make src and dest paths absolute. Determine destination base path.
-          link.dest = path.join(this.destination, link.dest);
-          link.src = path.join(project.directory, link.src);
-          let destBase = path.dirname(link.dest);
-          let type = 'file';
-
-          if (fs.statSync(link.src).isDirectory()) {
-            type = 'dir';
-          }
-
-          // If the source doesn't exist, skip this link.
-          if (!fs.existsSync(link.src)) {
-            this.aquifer.console.log('Source file does not exist. Skipping: ' + link.src, 'status');
-            return false;
-          }
-
-          // Handle existing destinations.
-          if (fs.existsSync(link.dest)) {
-            switch (link.conflict) {
-              case 'overwrite':
-                this.aquifer.console.log('Destination exists. Conflict set to overwrite. \nOverwriting: ' + link.dest, 'status');
-                del.sync(link.dest);
-                break;
-
-              case 'skip':
-                this.aquifer.console.log('Destination exists. Conflict set to skip. \nSkipping: ' + link.dest, 'status');
-                return false;
-
-              default:
-                return false;
-            }
-          }
-
-          // Make sure the destination base path exists.
-          if (!fs.existsSync(destBase)) {
-            this.aquifer.console.log('Destination directory does not exist. Creating: ' + destBase, 'status');
-            fs.mkdirsSync(destBase);
-          }
-
-          // If symlinking is not turned on or the individual link method is
-          // copy, copy the item.
-          if (!this.options.symlink || link.method === 'copy') {
-            fs.copySync(link.src, link.dest);
-          }
-          // Create symlink
-          else {
-            // Change current directory to the destination base path (minus last part of path).
-            process.chdir(destBase);
-
-            // Symlink the relative path of the src from the destination into the basename of the path.
-            fs.symlinkSync(path.relative(destBase, link.src), path.basename(link.dest), type);
-
-            // Change the working directory back to the original.
-            process.chdir(this.aquifer.cwd);
-          }
-        })
+        //links.forEach((link) => {
+        //  // Log this to the user.
+        //  this.aquifer.console.log(((!this.options.symlink || link.method === 'copy') ? 'Copying ' : 'Symlinking ') + link.src + ' => ' + link.dest)
+        //
+        //  // Make src and dest paths absolute. Determine destination base path.
+        //  link.dest = path.join(this.destination, link.dest);
+        //  link.src = path.join(project.directory, link.src);
+        //  let destBase = path.dirname(link.dest);
+        //  let type = 'file';
+        //
+        //  if (fs.statSync(link.src).isDirectory()) {
+        //    type = 'dir';
+        //  }
+        //
+        //  // If the source doesn't exist, skip this link.
+        //  if (!fs.existsSync(link.src)) {
+        //    this.aquifer.console.log('Source file does not exist. Skipping: ' + link.src, 'status');
+        //    return false;
+        //  }
+        //
+        //  // Handle existing destinations.
+        //  if (fs.existsSync(link.dest)) {
+        //    switch (link.conflict) {
+        //      case 'overwrite':
+        //        this.aquifer.console.log('Destination exists. Conflict set to overwrite. \nOverwriting: ' + link.dest, 'status');
+        //        del.sync(link.dest);
+        //        break;
+        //
+        //      case 'skip':
+        //        this.aquifer.console.log('Destination exists. Conflict set to skip. \nSkipping: ' + link.dest, 'status');
+        //        return false;
+        //
+        //      default:
+        //        return false;
+        //    }
+        //  }
+        //
+        //  // Make sure the destination base path exists.
+        //  if (!fs.existsSync(destBase)) {
+        //    this.aquifer.console.log('Destination directory does not exist. Creating: ' + destBase, 'status');
+        //    fs.mkdirsSync(destBase);
+        //  }
+        //
+        //  // If symlinking is not turned on or the individual link method is
+        //  // copy, copy the item.
+        //  if (!this.options.symlink || link.method === 'copy') {
+        //    fs.copySync(link.src, link.dest);
+        //  }
+        //  // Create symlink
+        //  else {
+        //    // Change current directory to the destination base path (minus last part of path).
+        //    process.chdir(destBase);
+        //
+        //    // Symlink the relative path of the src from the destination into the basename of the path.
+        //    fs.symlinkSync(path.relative(destBase, link.src), path.basename(link.dest), type);
+        //
+        //    // Change the working directory back to the original.
+        //    process.chdir(this.aquifer.cwd);
+        //  }
+        //})
       })
 
       // Run post-build commands.

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -151,7 +151,7 @@ class Build {
             addItems[item.src] = {
               destination: item.dest,
               required: typeof item.required !== 'undefined' ? item.required : false,
-              hook: "postBuild"
+              hook: 'postBuild'
             }
           });
 

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -150,7 +150,8 @@ class Build {
           this.options.addLinks.forEach(function(item) {
             addItems[item.src] = {
               destination: item.dest,
-              required: typeof item.required !== 'undefined' ? item.required : false
+              required: typeof item.required !== 'undefined' ? item.required : false,
+              hook: "postBuild"
             }
           });
 

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -10,7 +10,6 @@ const _ = require('lodash');
 const fs = require('fs-extra');
 const del = require('del');
 const path = require('path');
-const replace = require('replace');
 
 /**
  * Constructs build API for Aquifer.

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -58,6 +58,10 @@ class Build {
       let run = new this.aquifer.api.run(this.aquifer);
       let sync = new this.aquifer.api.sync(this.aquifer);
 
+      let items = sync.getBundleItemsMultiple(['directories', 'files']);
+      console.log(items);
+      reject();
+
       // Set class properties.
       this.destination = this.getAbsolutePath(destination);
       if (options) {
@@ -129,8 +133,10 @@ class Build {
         // point so let's combine the config.
         //let syncItems = _.defaults(project.config.sync.directories, project.config.sync.files);
 
-        sync.executeBundles(['files', 'directories'], destination, !this.options.symlink);
+        //sync.executeBundles(['files', 'directories'], destination, !this.options.symlink);
 
+        let items = sync.getBundleItemsMultiple(['files', 'directories']);
+        console.log(items);
 
         // Add links from options.
         links = links.concat(this.options.addLinks);

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -71,7 +71,6 @@ class Build {
         reject('Cannot build a project that hasn\'t been initialized.');
       }
 
-
       // Set some reasonable defaults.
       this.options.makeFile = project.getAbsolutePath(this.options.makeFile) || project.absolutePaths.makeFile;
       this.options.buildMethod = this.options.buildMethod || project.config.build.method;
@@ -133,7 +132,8 @@ class Build {
           // Provide the structure required by the Sync API.
           this.options.addLinks.forEach(function(item) {
             addItems[item.src] = {
-              destination: item.dest
+              destination: item.dest,
+              required: typeof item.required !== 'undefined' ? item.required : false
             }
           });
 
@@ -146,7 +146,7 @@ class Build {
         }
 
         // Execute syncing of the directories and files sync bundles.
-        sync.execute(destination, !this.options.symlink, ['directories', 'files']);
+        return sync.execute(destination, !this.options.symlink, ['directories', 'files']);
       })
 
       // Run post-build commands.

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -129,54 +129,8 @@ class Build {
         // point so let's combine the config.
         //let syncItems = _.defaults(project.config.sync.directories, project.config.sync.files);
 
+        sync.executeBundles(['files', 'directories'], destination, !this.options.symlink);
 
-        //
-        sync.executeBundles(['files', 'directories']);
-
-
-        //Object.keys(syncItems).forEach((key) => {
-        //  let item = syncItems[key];
-        //  item.source = key;
-        //  sync.execute(item, destination, !this.options.symlink);
-        //});
-
-
-
-
-
-        // Add items to the links array.
-        //Object.keys(syncItems).forEach((key) => {
-        //  // Make sure the source exists in the project.
-        //  if (fs.existsSync(path.join(project.directory, key))) {
-        //    let data = syncItems[key];
-        //
-        //    // If destination is the Drupal root and the source is a directory
-        //    // assume we want to copy/sync the contents. Iterate over contents
-        //    // add them to the links array individually.
-        //    if (!data.destination && fs.statSync(key).isDirectory()) {
-        //      fs.readdirSync(path.join(project.directory, key))
-        //        .filter((item) => {
-        //          return item.indexOf('.gitkeep') !== 0;
-        //        })
-        //        .forEach((item) => {
-        //          links.push({
-        //            src: path.join(key, item),
-        //            dest: item,
-        //            method: data.method,
-        //            conflict: data.conflict
-        //          });
-        //        });
-        //    }
-        //    else {
-        //      links.push({
-        //        src: key,
-        //        dest: data.destination,
-        //        method: data.method,
-        //        conflict: data.conflict
-        //      });
-        //    }
-        //  }
-        //});
 
         // Add links from options.
         links = links.concat(this.options.addLinks);

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -60,8 +60,6 @@ class Project {
 
       let localJsonPath = path.join(directory, 'aquifer.local.json');
 
-
-
       // Default directory to Aquifer.projectDir.
       this.directory = directory = directory || Aquifer.projectDir;
 
@@ -208,6 +206,22 @@ class Project {
     this.drupalVersion = version;
     this.srcDir = path.join(path.dirname(fs.realpathSync(__filename)), '../src', 'd' + this.drupalVersion);
     this.destPaths = destPaths[version];
+  }
+
+  /**
+   * Returns the absolute path of the input path within an Aquifer project.
+   *
+   * @param {string} relativePath relative path to an asset within an Aquifer
+   * project.
+   * @returns {string} absolute version of path.
+   */
+  getAbsolutePath(relativePath) {
+    let absolutePath = relativePath;
+    if (path.resolve(relativePath) !== relativePath) {
+      absolutePath = path.join(this.directory, relativePath);
+    }
+
+    return absolutePath;
   }
 }
 

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -126,12 +126,15 @@ class Project {
       fs.mkdirSync(path.join(this.directory, '.aquifer'));
 
       // Create Drupal sync directories.
-      Object.keys(this.config.sync.directories).forEach((key) => {
-        let data = this.config.sync.directories[key];
-        // Create directory.
-        fs.mkdirsSync(path.join(this.directory, key));
-        // Add .gitkeep.
-        touch.sync(path.join(this.directory, key, '.gitkeep'));
+      Object.keys(this.config.sync).forEach((key) => {
+        let item = this.config.sync[key];
+
+        if (typeof item.type !== 'undefined' && item.type === 'dir') {
+          // Create directory.
+          fs.mkdirsSync(path.join(this.directory, key));
+          // Add .gitkeep.
+          touch.sync(path.join(this.directory, key, '.gitkeep'));
+        }
       });
 
       // Copy over Aquifer src files.

--- a/lib/sync.api.js
+++ b/lib/sync.api.js
@@ -1,0 +1,145 @@
+/**
+ * @file
+ * Contains the Sync API for Aquifer.
+ */
+
+'use strict';
+
+// Load dependencies.
+const _ = require('lodash');
+const fs = require('fs-extra');
+const del = require('del');
+const path = require('path');
+
+/**
+ * Constructs the Sync API for Aquifer.
+ *
+ * @class
+ * @classdesc Contains the Sync API for Aquifer.
+ */
+class Sync {
+
+  /**
+   * Scaffolds properties and initializes class.
+   * @param {object} Aquifer Current instance of Aquifer.
+   * @returns {undefined} nothing.
+   */
+  constructor(Aquifer) {
+    this.aquifer = Aquifer;
+    this.project = this.aquifer.project;
+  }
+
+  /**
+   * Executes syncing of a single item.
+   * @param {object} item The item to sync.
+   * @param {string} buildDirectory Options to pass to spawn.
+   * @param {string} env The name of the environment on which to invoke.
+   * @returns {object} promise object.
+   */
+  execute(item, buildDirectory, forceCopy) {
+    buildDirectory = buildDirectory || this.project.config.build.directory;
+
+    return new Promise((resolve, reject) => {
+      // If destination is the Drupal root and the source is a directory
+      // assume we want to copy/sync the contents. Iterate over contents
+      // add them to the links array individually.
+      if (!item.destination && fs.statSync(path.join(this.project.directory, item.source)).isDirectory()) {
+        fs.readdirSync(path.join(this.project.directory, item.source))
+        .filter((child) => {
+          return child.indexOf('.gitkeep') !== 0;
+        })
+        .forEach((child) => {
+          let childItem = {
+            source: path.join(item.source, child),
+            destination: path.join(item.destination, child),
+            method: item.method || 'copy',
+            conflict: item.conflict || 'overwrite'
+          };
+
+          return this.execute(childItem, buildDirectory, forceCopy);
+        });
+      }
+      else {
+        // Log this to the user.
+        this.aquifer.console.log(((forceCopy || item.method === 'copy') ? 'Copying ' : 'Symlinking ') + item.source + ' => ' + item.destination);
+
+        // Make source and destination paths absolute.
+        item.source = path.join(this.project.directory, item.source);
+        item.destination = path.join(this.project.getAbsolutePath(buildDirectory), item.destination);
+
+        let destBase = path.dirname(item.destination);
+        let type = 'file';
+
+        if (fs.statSync(item.source).isDirectory()) {
+          type = 'dir';
+        }
+
+        // If the source doesn't exist, skip this item.
+        if (!fs.existsSync(item.source)) {
+          this.aquifer.console.log('Source file does not exist. Skipping: ' + item.source, 'status');
+          reject();
+        }
+
+        // Handle existing destinations.
+        if (fs.existsSync(item.destination)) {
+          switch (item.conflict) {
+            case 'overwrite':
+              this.aquifer.console.log('Destination exists. Conflict set to overwrite. \nOverwriting: ' + item.destination, 'status');
+              del.sync(item.destination);
+              break;
+
+            case 'skip':
+              this.aquifer.console.log('Destination exists. Conflict set to skip. \nSkipping: ' + item.destination, 'status');
+              reject();
+              break;
+
+            default:
+              reject();
+          }
+        }
+
+        // Make sure the destination base path exists.
+        if (!fs.existsSync(destBase)) {
+          this.aquifer.console.log('Destination directory does not exist. Creating: ' + destBase, 'status');
+          fs.mkdirsSync(destBase);
+        }
+
+        // If symlinking is not turned on or the individual link method is copy,
+        // copy the item.
+        if (forceCopy || item.method === 'copy') {
+          fs.copySync(item.source, item.destination);
+        }
+        // Create symlink
+        else {
+          // Change current directory to the destination base path (minus last
+          // part of path).
+          process.chdir(destBase);
+
+          // Symlink the relative path of the src from the destination into the
+          // basename of the path.
+          fs.symlinkSync(path.relative(destBase, item.source), path.basename(item.destination), type);
+
+          // Change the working directory back to the original.
+          process.chdir(this.aquifer.cwd);
+        }
+
+        resolve();
+      }
+    })
+  }
+
+  executeBundles(bundles, buildDirectory, forceCopy) {
+    let config = this.project.config.sync;
+    let sync = this;
+
+    bundles.forEach(function(bundle) {
+      _.forIn(config[bundle], function(item, key) {
+        item.source = key;
+        sync.execute(item, buildDirectory, forceCopy);
+      });
+    });
+  }
+
+}
+
+module.exports = Sync;

--- a/lib/sync.api.js
+++ b/lib/sync.api.js
@@ -132,12 +132,20 @@ class Sync {
     let config = this.project.config.sync;
     let sync = this;
 
+    // TODO: Add promise chain
+
     bundles.forEach(function(bundle) {
       _.forIn(config[bundle], function(item, key) {
         item.source = key;
         sync.execute(item, buildDirectory, forceCopy);
       });
     });
+  }
+
+  executeAll(buildDirectory, forceCopy) {
+    let config = this.project.config.sync;
+    let bundles = Object.keys(config);
+    this.executeBundles(bundles, buildDirectory, forceCopy);
   }
 
 }

--- a/lib/sync.api.js
+++ b/lib/sync.api.js
@@ -50,9 +50,8 @@ class Sync {
 
     let sync = this;
     let itemsArr = this.getItems(hook, type);
-    let aquiferConsole = this.aquifer.console;
 
-    aquiferConsole.log('Starting ' + (hook ? hook + ' ' : '') + 'sync...');
+    this.aquifer.console.log('Starting ' + (hook ? hook + ' ' : '') + 'sync...');
 
     // Process items.
     let itemPromises = itemsArr.map(
@@ -65,11 +64,11 @@ class Sync {
       .then(function () {
         // Reset items and excluded items.
         sync.reset();
-        aquiferConsole.log((hook ? hook + ' s' : 'S') + 'ync complete.');
+        this.aquifer.console.log((hook ? hook + ' s' : 'S') + 'ync complete.');
       })
       .catch(function (error) {
         sync.reset();
-        aquiferConsole.log(error, 'error');
+        this.aquifer.console.log(error, 'error');
       });
   }
 
@@ -98,7 +97,7 @@ class Sync {
       // getting overwritten. This is an unwanted misconfiguration; abort the
       // build.
       if (!item.destination && !item.contents && fs.statSync(path.join(this.project.directory, item.source)).isDirectory()) {
-        aquiferConsole.log('Source "' + item.source + '" will overwrite the build directory. Set the "contents" property to true to sync contents only.', 'error');
+        this.aquifer.console.log('Source "' + item.source + '" will overwrite the build directory. Set the "contents" property to true to sync contents only.', 'error');
       }
 
       // Item must have a source property defined.
@@ -125,7 +124,7 @@ class Sync {
 
             this.executeItem(childItem, buildDirectory, forceCopy)
               .catch(function (error) {
-                aquiferConsole.log('Error: ' + error, 'error');
+                this.aquifer.console.log('Error: ' + error, 'error');
               });
           });
 
@@ -134,7 +133,7 @@ class Sync {
       }
 
       // Log sync action.
-      aquiferConsole.log(((forceCopy || item.method === 'copy') ? 'Copying: ' : 'Symlinking: ') + item.source + ' => ' + item.destination);
+      this.aquifer.console.log(((forceCopy || item.method === 'copy') ? 'Copying: ' : 'Symlinking: ') + item.source + ' => ' + item.destination);
 
       // Make source and destination paths absolute.
       item.source = path.join(this.project.directory, item.source);
@@ -147,7 +146,7 @@ class Sync {
           return;
         }
         else {
-          aquiferConsole.log('Source does not exist: ' + item.source + '. Skipping.', 'status');
+          this.aquifer.console.log('Source does not exist: ' + item.source + '. Skipping.', 'status');
           resolve();
           return;
         }
@@ -157,13 +156,13 @@ class Sync {
       if (fs.existsSync(item.destination)) {
         switch (item.conflict) {
           case 'overwrite':
-            aquiferConsole.log('Destination exists. Conflict set to overwrite. \nOverwriting: ' + item.destination, 'status');
+            this.aquifer.console.log('Destination exists. Conflict set to overwrite. \nOverwriting: ' + item.destination, 'status');
             del.sync(item.destination);
 
             break;
 
           case 'skip':
-            aquiferConsole.log('Destination exists. Conflict set to skip. \nSkipping: ' + item.destination, 'status');
+            this.aquifer.console.log('Destination exists. Conflict set to skip. \nSkipping: ' + item.destination, 'status');
             resolve();
             return;
 
@@ -172,7 +171,7 @@ class Sync {
               reject('Error: Required item failed to sync. Unsupported or empty conflict property for: ' + item.source);
             }
             else {
-              aquiferConsole.log('Unsupported or empty conflict property for: ' + item.source + '. Skipping.', 'status');
+              this.aquifer.console.log('Unsupported or empty conflict property for: ' + item.source + '. Skipping.', 'status');
             }
         }
       }
@@ -181,7 +180,7 @@ class Sync {
       let destBase = path.dirname(item.destination);
 
       if (!fs.existsSync(destBase)) {
-        aquiferConsole.log('Destination directory does not exist. Creating: ' + destBase, 'status');
+        this.aquifer.console.log('Destination directory does not exist. Creating: ' + destBase, 'status');
         fs.mkdirsSync(destBase);
       }
 
@@ -290,7 +289,7 @@ class Sync {
         }
         // Otherwise skip it and inform the user.
         else {
-          aquiferConsole.log('Excluding: ' + key + ' => ' + item.destination);
+          this.aquifer.console.log('Excluding: ' + key + ' => ' + item.destination);
         }
       });
     }

--- a/lib/sync.api.js
+++ b/lib/sync.api.js
@@ -91,17 +91,25 @@ class Sync {
       item.method = typeof item.method !== 'undefined' ? item.method : 'copy';
       item.conflict = typeof item.conflict !== 'undefined' ? item.conflict : 'overwrite';
       item.required = typeof item.required !== 'undefined' ? item.required : false;
+      item.contents = typeof item.contents !== 'undefined' ? item.contents : false;
+
+      // If item.destination is the build directory and item.source is a
+      // directory and item.contents is false, prevent the build directory from
+      // getting overwritten. This is an unwanted misconfiguration; abort the
+      // build.
+      if (!item.destination && !item.contents && fs.statSync(path.join(this.project.directory, item.source)).isDirectory()) {
+        aquiferConsole.log('Source "' + item.source + '" will overwrite the build directory. Set the "contents" property to true to sync contents only.', 'error');
+      }
 
       // Item must have a source property defined.
       if (typeof item.source === 'undefined' || !item.source) {
-        reject('Item with destination ' + item.destination + ' has no source property defined. Skipping.');
+        reject('Item with destination ' + item.destination + ' has no source defined. Skipping.');
         return;
       }
 
-      // If destination is the Drupal root and the source is a directory
-      // assume we want to copy/sync the contents. Iterate over contents
-      // add them to the links array individually.
-      if (!item.destination && fs.statSync(path.join(this.project.directory, item.source)).isDirectory()) {
+      // If item.source is a directory and item.contents is set to true, sync
+      // the contents individually instead of the parent directory.
+      if (item.contents && fs.statSync(path.join(this.project.directory, item.source)).isDirectory()) {
         fs.readdirSync(path.join(this.project.directory, item.source))
           .filter((child) => {
             return child.indexOf('.gitkeep') !== 0;

--- a/lib/sync.api.js
+++ b/lib/sync.api.js
@@ -38,10 +38,6 @@ class Sync {
    *   defined in aquifer.json.
    * @param {boolean} [forceCopy=false] Set true to force copying over
    *   symlinking for all items.
-   * @param {(boolean|array)} [bundles=true] Set true to include all sync
-   *   bundles in the sync, false to not include any of the defined sync
-   *   bundles. Enter an array of sync bundle names to include only those
-   *   bundles in the sync.
    * @param {string} hook Name of the hook being called. Optional.
    * @param {string} type Type of items to sync: 'file' or 'dir'. Optional.
    * @returns {object} promise object.

--- a/lib/sync.api.js
+++ b/lib/sync.api.js
@@ -48,28 +48,22 @@ class Sync {
     hook = hook || false;
     type = type || false;
 
-    let sync = this;
-    let itemsArr = this.getItems(hook, type);
+    return this.getItems(hook, type)
+    .then((itemsArr) => {
+      this.aquifer.console.log('Starting ' + (hook ? hook + ' ' : '') + 'sync...');
 
-    this.aquifer.console.log('Starting ' + (hook ? hook + ' ' : '') + 'sync...');
-
-    // Process items.
-    let itemPromises = itemsArr.map(
-      function (item) {
-        return sync.executeItem(item, buildDirectory, forceCopy);
-      }
-    );
-
-    return Promise.all(itemPromises)
-      .then(function () {
-        // Reset items and excluded items.
-        sync.reset();
-        sync.aquifer.console.log((hook ? hook + ' s' : 'S') + 'ync complete.');
-      })
-      .catch(function (error) {
-        sync.reset();
-        sync.aquifer.console.log(error, 'error');
+      // Process items.
+      let itemPromises = itemsArr.map((item) => {
+        return this.executeItem(item, buildDirectory, forceCopy);
       });
+
+      return Promise.all(itemPromises)
+    })
+    .then(() => {
+      // Reset items and excluded items.
+      this.reset();
+      this.aquifer.console.log((hook ? hook + ' s' : 'S') + 'ync complete.');
+    })
   }
 
   /**
@@ -112,26 +106,32 @@ class Sync {
       // If item.source is a directory and item.contents is set to true, sync
       // the contents individually instead of the parent directory.
       if (item.contents && fs.statSync(path.join(this.project.directory, item.source)).isDirectory()) {
+        let contentsChain = [];
+
         fs.readdirSync(path.join(this.project.directory, item.source))
-          .filter((child) => {
-            return child.indexOf('.gitkeep') !== 0;
-          })
-          .forEach((child) => {
-            let childItem = {
-              source: path.join(item.source, child),
-              destination: path.join(item.destination, child),
-              method: item.method,
-              conflict: item.conflict,
-              required: item.required
-            };
+        .filter((child) => {
+          return child.indexOf('.gitkeep') !== 0;
+        })
+        .forEach((child) => {
+          let childItem = {
+            source: path.join(item.source, child),
+            destination: path.join(item.destination, child),
+            method: item.method,
+            conflict: item.conflict,
+            required: item.required
+          };
 
-            this.executeItem(childItem, buildDirectory, forceCopy)
-              .catch(function (error) {
-                this.aquifer.console.log('Error: ' + error, 'error');
-              });
-          });
+          contentsChain.push(this.executeItem(childItem, buildDirectory, forceCopy));
+        });
 
-        resolve();
+        Promise.all(contentsChain)
+        .then(() => {
+          resolve();
+        })
+        .catch((reason) => {
+          reject(reason);
+        })
+
         return;
       }
 
@@ -172,6 +172,7 @@ class Sync {
           default:
             if (item.required) {
               reject('Error: Required item failed to sync. Unsupported or empty conflict property for: ' + item.source);
+              return;
             }
             else {
               this.aquifer.console.log('Unsupported or empty conflict property for: ' + item.source + '. Skipping.', 'status');
@@ -217,6 +218,7 @@ class Sync {
       // Validate required item exists.
       if (item.required && !fs.existsSync(item.destination)) {
         reject('Error: Required item failed to sync: ' + item.source);
+        return;
       }
 
       // Validate symlinks and copies.
@@ -225,10 +227,12 @@ class Sync {
 
         if ((forceCopy || item.method === 'copy') && stat.isSymbolicLink()) {
           reject('Error: Item symlinked instead of copied: ' + item.destination);
+          return;
         }
 
         if (!forceCopy && item.method === 'symlink' && !stat.isSymbolicLink()) {
           reject('Error: Item copied instead of symlinked: ' + item.destination);
+          return;
         }
       }
 
@@ -240,63 +244,77 @@ class Sync {
    * Gets items defined in a single sync bundle.
    * @param {string} hook Name of the hook being called. Optional.
    * @param {string} type Type of items to sync: 'file' or 'dir'. Optional.
-   * @returns {array} Sync items defined for the bundle.
+   * @returns {object} promise object which is resolved with the items array.
    */
   getItems(hook, type) {
-    hook = hook || false;
-    type = type || false;
-    let items = this.items;
-    let configItems = this.config.sync;
-    let itemsArr = [];
-    let itemsExcluded = this.itemsExcluded;
+    return new Promise((resolve, reject) => {
+      hook = hook || false;
+      type = type || false;
+      let items = this.items;
+      let configItems = this.config.sync;
+      let itemsArr = [];
+      let itemsExcluded = this.itemsExcluded;
 
-    // Combine items from configuration with added items.
-    items = _.defaults(items, configItems);
+      // Combine items from configuration with added items.
+      items = _.defaults(items, configItems);
 
-    // Iterate items object and add items to the items array for processing.
-    if (!_.isEmpty(items)) {
-      _.forIn(items, function (item, key) {
-        // If a hook is specified and item does not have that hook.
-        if (hook && (item.hook == 'undefined' || item.hook !== hook)) {
-          return;
-        }
+      // Add the source property.
+      _.forIn(items, (item, key) => {
+        item.source = key;
+      })
 
-        if (type) {
-          if (item.type == 'undefined') {
-            let source = path.join(this.project.directory, key);
+      // Validate items.
+      this.validateItems(items)
 
-            if (fs.existsSync(source)) {
-              let type = 'file';
-
-              if (fs.statSync(source).isDirectory()) {
-                type = 'dir';
-              }
-
-              item.type = type;
-            }
-            else {
-              item.type = false;
-            }
-          }
-
-          if (!item.type || item.type !== type) {
+      // Iterate items object and add items to the items array for processing.
+      .then(() => {
+        _.forIn(items, (item, key) => {
+          // If a hook is specified and item does not have that hook.
+          if (hook && (!item.hasOwnProperty('hook') || item.hook !== hook)) {
             return;
           }
-        }
 
-        // If item is not excluded, add to the array.
-        if (itemsExcluded.indexOf(item.destination) === -1) {
-          item.source = key;
-          itemsArr.push(item);
-        }
-        // Otherwise skip it and inform the user.
-        else {
-          this.aquifer.console.log('Excluding: ' + key + ' => ' + item.destination);
-        }
-      });
-    }
+          if (type) {
+            if (!item.hasOwnProperty('type')) {
+              let source = path.join(this.project.directory, key);
 
-    return itemsArr;
+              if (fs.existsSync(source)) {
+                let type = 'file';
+
+                if (fs.statSync(source).isDirectory()) {
+                  type = 'dir';
+                }
+
+                item.type = type;
+              }
+              else {
+                item.type = false;
+              }
+            }
+
+            if (!item.type || item.type !== type) {
+              return;
+            }
+          }
+
+          // If item is not excluded, add to the array.
+          if (itemsExcluded.indexOf(item.destination) === -1) {
+            itemsArr.push(item);
+          }
+          // Otherwise skip it and inform the user.
+          else {
+            this.aquifer.console.log('Excluding: ' + key + ' => ' + item.destination);
+          }
+        })
+
+        resolve(itemsArr);
+      })
+
+      // Report up the chain if there was a problem.
+      .catch((reason) => {
+        reject(reason);
+      })
+    });
   }
 
   /**
@@ -341,6 +359,45 @@ class Sync {
     this.itemsExcluded = [];
   }
 
+  /**
+   * Validates all sync items.
+   * @param {object} items An object containing sync items to validate.
+   * @returns {object} A promise object.
+   */
+  validateItems(items) {
+    return new Promise((resolve, reject) => {
+      let chain = [];
+      _.forIn(items, (item, key) => {
+        chain.push(this.validateItem(item, key));
+      });
+      Promise.all(chain)
+      .then(() => {
+        resolve();
+      })
+      .catch((reason) => {
+        reject(reason);
+      })
+    })
+  }
+
+  /**
+   * Validates a sync item.
+   * @param {object} item The item to validate.
+   * @param {string} key The key of the sync item in aquifer.json.
+   * @returns {object} A promise object.
+   */
+  validateItem(item, key) {
+    return new Promise((resolve, reject) => {
+      // item.source must exist and must not be falsey. item.destination must
+      // exist, but it can be falsey. In the case it is an empty string it will cause the synced item to be placed in the build root.
+      if (!item.hasOwnProperty('source') || !item.source || !item.hasOwnProperty('destination')) {
+        reject('The "' + key + '" sync item is misonfigured. Check that it contains a destination property in aquifer.json.');
+        return;
+      }
+
+      resolve();
+    })
+  }
 }
 
 module.exports = Sync;

--- a/lib/sync.api.js
+++ b/lib/sync.api.js
@@ -27,6 +27,53 @@ class Sync {
   constructor(Aquifer) {
     this.aquifer = Aquifer;
     this.project = this.aquifer.project;
+    this.config = this.project.config;
+    this.addItems = [];
+    this.removeItems = [];
+  }
+
+  execute(buildDirectory=this.config.build.directory, forceCopy, bundles) {
+    let buildDirectory = typeof buildDirectory !== 'undefined' ?  buildDirectory : this.config.build.directory;
+    let forceCopy = typeof forceCopy !== 'undefined' ?  buildDirectory : this.config.build.directory;
+    let buildDirectory = typeof buildDirectory !== 'undefined' ?  buildDirectory : this.config.build.directory;
+    //let items = this.addItems;
+    //
+    //if (bundles.length > 0) {
+    //  bundles.forEach(function(bundle) {
+    //    _.forIn(config[bundle], function(item, key) {
+    //      //item.source = key;
+    //      //sync.executeItem(item, buildDirectory, forceCopy);
+    //      items.push(item);
+    //    });
+    //  });
+    //}
+    //else {
+    //  let bundles = Object.keys(this.config);
+    //}
+
+
+  }
+
+  getBundleItems(bundle) {
+    let items = {};
+
+    _.forIn(this.config.sync[bundle], function(item, key) {
+      items[key] = item;
+    });
+
+    return items;
+  }
+
+  getBundleItemsMultiple(bundles) {
+    let items = {};
+    let sync = this;
+
+    bundles.forEach(function(bundle) {
+      console.log(bundle);
+      items = _.defaults(items, sync.getBundleItems(bundle));
+    });
+
+    return items;
   }
 
   /**
@@ -36,7 +83,7 @@ class Sync {
    * @param {string} env The name of the environment on which to invoke.
    * @returns {object} promise object.
    */
-  execute(item, buildDirectory, forceCopy) {
+  executeItem(item, buildDirectory, forceCopy) {
     buildDirectory = buildDirectory || this.project.config.build.directory;
 
     return new Promise((resolve, reject) => {
@@ -56,7 +103,7 @@ class Sync {
             conflict: item.conflict || 'overwrite'
           };
 
-          return this.execute(childItem, buildDirectory, forceCopy);
+          return this.executeItem(childItem, buildDirectory, forceCopy);
         });
       }
       else {
@@ -137,7 +184,7 @@ class Sync {
     bundles.forEach(function(bundle) {
       _.forIn(config[bundle], function(item, key) {
         item.source = key;
-        sync.execute(item, buildDirectory, forceCopy);
+        sync.executeItem(item, buildDirectory, forceCopy);
       });
     });
   }

--- a/lib/sync.api.js
+++ b/lib/sync.api.js
@@ -32,6 +32,237 @@ class Sync {
   }
 
   /**
+   * Executes syncing of items.
+   * @param {string} [buildDirectory=Aquifer.config.build.directory] Build
+   *   directory relative to the project root. Defaults to build directory
+   *   defined in aquifer.json.
+   * @param {boolean} [forceCopy=false] Set true to force copying over
+   *   symlinking for all items.
+   * @param {(boolean|array)} [bundles=true] Set true to include all sync
+   *   bundles in the sync, false to not include any of the defined sync
+   *   bundles. Enter an array of sync bundle names to include only those
+   *   bundles in the sync.
+   * @returns {object} promise object.
+   */
+  execute(buildDirectory, forceCopy, bundles) {
+    buildDirectory = typeof buildDirectory !== 'undefined' ? buildDirectory : this.config.build.directory;
+    forceCopy = typeof forceCopy !== 'undefined' ? forceCopy : false;
+    bundles = typeof bundles !== 'undefined' ? bundles : true;
+    let sync = this;
+    let items = this.items;
+    let itemsArr = [];
+    let itemsExcluded = this.itemsExcluded;
+    let aquiferConsole = this.aquifer.console;
+
+    aquiferConsole.log('Starting sync...');
+
+    // If bundles is true, queue all bundles.
+    if (bundles === true) {
+      bundles = Object.keys(this.config.sync);
+    }
+
+    // Queue defined bundles.
+    if (Array.isArray(bundles) && bundles.length > 0) {
+      items = _.defaults(items, this.getBundleItemsMultiple(bundles));
+    }
+
+    // Iterate items object and add items to the items array for processing.
+    if (!_.isEmpty(items)) {
+      _.forIn(items, function (item, key) {
+        // If item is not excluded, add to the array.
+        if (itemsExcluded.indexOf(item.destination) === -1) {
+          item.source = key;
+          itemsArr.push(item);
+        }
+          // Otherwise skip it and inform the user.
+        else {
+          aquiferConsole.log('Excluding: ' + key + ' => ' + item.destination);
+        }
+      });
+    }
+    else {
+      aquiferConsole.log('Nothing to sync.');
+    }
+
+    // Process items.
+    let itemPromises = itemsArr.map(
+      function (item) {
+        return sync.executeItem(item, buildDirectory, forceCopy);
+      }
+    );
+
+    return Promise.all(itemPromises)
+      .then(function (results) {
+        // Reset items and excluded items.
+        sync.reset();
+        aquiferConsole.log('Sync complete.');
+      })
+      .catch(function (error) {
+        sync.reset();
+        aquiferConsole.log(error, 'error');
+      });
+  }
+
+  /**
+   * Executes syncing of a single item.
+   * @param {object} item The item to sync.
+   * @param {string} buildDirectory Build directory relative to the project
+   *   root. Defaults to build directory defined in aquifer.json.
+   * @param {boolean} forceCopy Set true to force copying over symlinking for
+   *   all items. Defaults to false.
+   * @returns {object} promise object.
+   */
+  executeItem(item, buildDirectory, forceCopy) {
+    buildDirectory = typeof buildDirectory !== 'undefined' ? buildDirectory : this.config.build.directory;
+    forceCopy = typeof forceCopy !== 'undefined' ? forceCopy : true;
+
+    return new Promise((resolve, reject) => {
+      let aquiferConsole = this.aquifer.console;
+      item.method = typeof item.method !== 'undefined' ? item.method : 'copy';
+      item.conflict = typeof item.conflict !== 'undefined' ? item.conflict : 'overwrite';
+      item.required = typeof item.required !== 'undefined' ? item.required : false;
+
+      // Item must have a source property defined.
+      if (typeof item.source === 'undefined' || !item.source) {
+        reject('Item with destination ' + item.destination + ' has no source property defined. Skipping.');
+        return;
+      }
+
+      // If destination is the Drupal root and the source is a directory
+      // assume we want to copy/sync the contents. Iterate over contents
+      // add them to the links array individually.
+      if (!item.destination && fs.statSync(path.join(this.project.directory, item.source)).isDirectory()) {
+        fs.readdirSync(path.join(this.project.directory, item.source))
+          .filter((child) => {
+            return child.indexOf('.gitkeep') !== 0;
+          })
+          .forEach((child) => {
+            let childItem = {
+              source: path.join(item.source, child),
+              destination: path.join(item.destination, child),
+              method: item.method,
+              conflict: item.conflict,
+              required: item.required
+            };
+
+            this.executeItem(childItem, buildDirectory, forceCopy)
+              .catch(function (error) {
+                aquiferConsole.log('Error: ' + error, 'error');
+              });
+          });
+
+        resolve();
+        return;
+      }
+
+      // Log sync action.
+      aquiferConsole.log(((forceCopy || item.method === 'copy') ? 'Copying: ' : 'Symlinking: ') + item.source + ' => ' + item.destination);
+
+      // Make source and destination paths absolute.
+      item.source = path.join(this.project.directory, item.source);
+      item.destination = path.join(this.project.getAbsolutePath(buildDirectory), item.destination);
+
+      // If the source doesn't exist, skip this item.
+      if (!fs.existsSync(item.source)) {
+        if (item.required) {
+          reject('Error: Required item failed to sync. Source does not exist: ' + item.source);
+          return;
+        }
+        else {
+          aquiferConsole.log('Source does not exist: ' + item.source + '. Skipping.', 'status');
+          resolve();
+          return;
+        }
+      }
+
+      // Handle existing destinations.
+      if (fs.existsSync(item.destination)) {
+        switch (item.conflict) {
+          case 'overwrite':
+            aquiferConsole.log('Destination exists. Conflict set to overwrite. \nOverwriting: ' + item.destination, 'status');
+            del.sync(item.destination);
+            break;
+
+          case 'skip':
+            aquiferConsole.log('Destination exists. Conflict set to skip. \nSkipping: ' + item.destination, 'status');
+            resolve();
+            return;
+
+          default:
+            if (item.required) {
+              reject('Error: Required item failed to sync. Unsupported or empty conflict property for: ' + item.source);
+            }
+            else {
+              aquiferConsole.log('Unsupported or empty conflict property for: ' + item.source + '. Skipping.', 'status');
+            }
+        }
+
+        return;
+      }
+
+      // Make sure the destination base path exists.
+      let destBase = path.dirname(item.destination);
+
+      if (!fs.existsSync(destBase)) {
+        aquiferConsole.log('Destination directory does not exist. Creating: ' + destBase, 'status');
+        fs.mkdirsSync(destBase);
+      }
+
+      // If symlinking is not turned on or the individual link method is copy,
+      // copy the item.
+      if (forceCopy || item.method === 'copy') {
+        fs.copySync(item.source, item.destination);
+      }
+      // Otherwise create a symlink.
+      else {
+        let type = 'file';
+
+        if (fs.statSync(item.source).isDirectory()) {
+          type = 'dir';
+        }
+
+        // Change current directory to the destination base path (minus last
+        // part of path).
+        process.chdir(destBase);
+
+        // Symlink the relative path of the src from the destination into the
+        // basename of the path.
+        fs.symlinkSync(path.relative(destBase, item.source), path.basename(item.destination), type);
+
+        // Change the working directory back to the original.
+        process.chdir(this.aquifer.cwd);
+      }
+
+      resolve();
+    })
+  }
+
+  /**
+   * Gets items defined in a single sync bundle.
+   * @param {string} bundle Name of the sync bundle.
+   * @returns {object} Sync items defined for the bundle.
+   */
+  getBundleItems(bundle) {
+    return this.config.sync[bundle];
+  }
+
+  /**
+   * Gets items defined in multiple sync bundles.
+   * @param {array} bundles An array of sync bundle names.
+   * @returns {object} Sync items defined for the bundles.
+   */
+  getBundleItemsMultiple(bundles) {
+    let items = {};
+    let sync = this;
+
+    bundles.forEach(function(bundle) {
+      items = _.defaults(items, sync.getBundleItems(bundle));
+    });
+
+    return items;
+  }
+
+  /**
    * Add items to the next sync execution.
    * @example
    * let items = {
@@ -65,178 +296,14 @@ class Sync {
   }
 
   /**
-   * Executes syncing of items.
-   * @param {string} buildDirectory Build directory relative to the project
-   *   root. Defaults to build directory defined in aquifer.json.
-   * @param {boolean} forceCopy Set true to force copying over symlinking for
-   *   all items. Defaults to false.
-   * @param {array} bundles Set true to force copying over symlinking for
-   *   all items. Defaults to all sync bundles defined in aquifer.json.
-   * @returns {object} promise object.
+   * Resets items object and excluded items array.
+   * @returns {undefined} nothing.
    */
-  execute(buildDirectory, forceCopy, bundles) {
-    this.aquifer.console.log('Beginning sync...');
-    buildDirectory = typeof buildDirectory !== 'undefined' ? buildDirectory : this.config.build.directory;
-    forceCopy = typeof forceCopy !== 'undefined' ? forceCopy : false;
-    bundles = typeof bundles !== 'undefined' ? bundles : Object.keys(this.config.sync);
-    let sync = this;
-    let items = this.items;
-    let itemsExcluded = this.itemsExcluded;
-
-    if (bundles.length > 0) {
-      items = _.defaults(items, this.getBundleItemsMultiple(bundles));
-    }
-
-    _.forIn(items, function(item, key) {
-      if (itemsExcluded.indexOf(item.destination) === -1) {
-        item.source = key;
-        return sync.executeItem(item, buildDirectory, forceCopy);
-      }
-      else {
-        console.log('Excluding: ' + key + ' => ' + item.destination);
-      }
-    });
-
-    // Reset items and excluded items.
+  reset() {
     this.items = {};
     this.itemsExcluded = [];
-    this.aquifer.console.log('Sync complete.');
   }
 
-  /**
-   * Gets items defined in a single sync bundle.
-   * @param {string} bundle Name of the sync bundle.
-   * @returns {object} Sync items defined for the bundle.
-   */
-  getBundleItems(bundle) {
-    return this.config.sync[bundle];
-  }
-
-  /**
-   * Gets items defined in multiple sync bundles.
-   * @param {array} bundles An array of sync bundle names.
-   * @returns {object} Sync items defined for the bundles.
-   */
-  getBundleItemsMultiple(bundles) {
-    let items = {};
-    let sync = this;
-
-    bundles.forEach(function(bundle) {
-      items = _.defaults(items, sync.getBundleItems(bundle));
-    });
-
-    return items;
-  }
-
-  /**
-   * Executes syncing of a single item.
-   * @param {object} item The item to sync.
-   * @param {string} buildDirectory Build directory relative to the project
-   *   root. Defaults to build directory defined in aquifer.json.
-   * @param {boolean} forceCopy Set true to force copying over symlinking for
-   *   all items. Defaults to false.
-   * @returns {object} promise object.
-   */
-  executeItem(item, buildDirectory, forceCopy) {
-    buildDirectory = typeof buildDirectory !== 'undefined' ? buildDirectory : this.config.build.directory;
-    forceCopy = typeof forceCopy !== 'undefined' ? forceCopy : false;
-
-    return new Promise((resolve, reject) => {
-      item.method = item.method || 'copy';
-      item.conflict = item.conflict || 'overwrite';
-
-      if (!item.source) {
-        this.aquifer.console.log('Item with destination ' + item.destination + ' has no source property defined. Skipping.');
-        return false;
-      }
-
-      // If destination is the Drupal root and the source is a directory
-      // assume we want to copy/sync the contents. Iterate over contents
-      // add them to the links array individually.
-      if (!item.destination && fs.statSync(path.join(this.project.directory, item.source)).isDirectory()) {
-        fs.readdirSync(path.join(this.project.directory, item.source))
-        .filter((child) => {
-          return child.indexOf('.gitkeep') !== 0;
-        })
-        .forEach((child) => {
-          let childItem = {
-            source: path.join(item.source, child),
-            destination: path.join(item.destination, child),
-            method: item.method,
-            conflict: item.conflict
-          };
-
-          return this.executeItem(childItem, buildDirectory, forceCopy);
-        });
-      }
-      else {
-        // Log this to the user.
-        this.aquifer.console.log(((forceCopy || item.method === 'copy') ? 'Copying: ' : 'Symlinking: ') + item.source + ' => ' + item.destination);
-
-        // Make source and destination paths absolute.
-        item.source = path.join(this.project.directory, item.source);
-        item.destination = path.join(this.project.getAbsolutePath(buildDirectory), item.destination);
-
-        // If the source doesn't exist, skip this item.
-        if (!fs.existsSync(item.source)) {
-          this.aquifer.console.log('Source file does not exist. Skipping: ' + item.source, 'status');
-          return false;
-        }
-
-        // Handle existing destinations.
-        if (fs.existsSync(item.destination)) {
-          switch (item.conflict) {
-            case 'overwrite':
-              this.aquifer.console.log('Destination exists. Conflict set to overwrite. \nOverwriting: ' + item.destination, 'status');
-              del.sync(item.destination);
-              break;
-
-            case 'skip':
-              this.aquifer.console.log('Destination exists. Conflict set to skip. \nSkipping: ' + item.destination, 'status');
-              return false;
-
-            default:
-              return false;
-          }
-        }
-
-        // Make sure the destination base path exists.
-        let destBase = path.dirname(item.destination);
-
-        if (!fs.existsSync(destBase)) {
-          this.aquifer.console.log('Destination directory does not exist. Creating: ' + destBase, 'status');
-          fs.mkdirsSync(destBase);
-        }
-
-        // If symlinking is not turned on or the individual link method is copy,
-        // copy the item.
-        if (forceCopy || item.method === 'copy') {
-          fs.copySync(item.source, item.destination);
-        }
-        // Otherwise create a symlink.
-        else {
-          let type = 'file';
-
-          if (fs.statSync(item.source).isDirectory()) {
-            type = 'dir';
-          }
-
-          // Change current directory to the destination base path (minus last
-          // part of path).
-          process.chdir(destBase);
-
-          // Symlink the relative path of the src from the destination into the
-          // basename of the path.
-          fs.symlinkSync(path.relative(destBase, item.source), path.basename(item.destination), type);
-
-          // Change the working directory back to the original.
-          process.chdir(this.aquifer.cwd);
-        }
-
-        resolve();
-      }
-    })
-  }
 }
 
 module.exports = Sync;

--- a/lib/sync.api.js
+++ b/lib/sync.api.js
@@ -64,11 +64,11 @@ class Sync {
       .then(function () {
         // Reset items and excluded items.
         sync.reset();
-        this.aquifer.console.log((hook ? hook + ' s' : 'S') + 'ync complete.');
+        sync.aquifer.console.log((hook ? hook + ' s' : 'S') + 'ync complete.');
       })
       .catch(function (error) {
         sync.reset();
-        this.aquifer.console.log(error, 'error');
+        sync.aquifer.console.log(error, 'error');
       });
   }
 

--- a/lib/sync.api.js
+++ b/lib/sync.api.js
@@ -389,7 +389,8 @@ class Sync {
   validateItem(item, key) {
     return new Promise((resolve, reject) => {
       // item.source must exist and must not be falsey. item.destination must
-      // exist, but it can be falsey. In the case it is an empty string it will cause the synced item to be placed in the build root.
+      // exist, but it can be falsey. In the case it is an empty string it will
+      // cause the synced item to be placed in the build root.
       if (!item.hasOwnProperty('source') || !item.source || !item.hasOwnProperty('destination')) {
         reject('The "' + key + '" sync item is misonfigured. Check that it contains a destination property in aquifer.json.');
         return;

--- a/lib/sync.api.js
+++ b/lib/sync.api.js
@@ -13,7 +13,6 @@ const path = require('path');
 
 /**
  * Constructs the Sync API for Aquifer.
- *
  * @class
  * @classdesc Contains the Sync API for Aquifer.
  */
@@ -28,48 +27,101 @@ class Sync {
     this.aquifer = Aquifer;
     this.project = this.aquifer.project;
     this.config = this.project.config;
-    this.addItems = [];
-    this.removeItems = [];
+    this.items = {};
+    this.itemsExcluded = [];
   }
 
-  execute(buildDirectory=this.config.build.directory, forceCopy, bundles) {
-    let buildDirectory = typeof buildDirectory !== 'undefined' ?  buildDirectory : this.config.build.directory;
-    let forceCopy = typeof forceCopy !== 'undefined' ?  buildDirectory : this.config.build.directory;
-    let buildDirectory = typeof buildDirectory !== 'undefined' ?  buildDirectory : this.config.build.directory;
-    //let items = this.addItems;
-    //
-    //if (bundles.length > 0) {
-    //  bundles.forEach(function(bundle) {
-    //    _.forIn(config[bundle], function(item, key) {
-    //      //item.source = key;
-    //      //sync.executeItem(item, buildDirectory, forceCopy);
-    //      items.push(item);
-    //    });
-    //  });
-    //}
-    //else {
-    //  let bundles = Object.keys(this.config);
-    //}
-
-
+  /**
+   * Add items to the next sync execution.
+   * @example
+   * let items = {
+   *   "path/to/dir/in/project": {
+   *     "destination": "path/to/dir/in/build",
+   *     "method": "symlink",
+   *     "conflict": "overwrite"
+   *   }
+   * }
+   * sync.addItems(items);
+   * @param {object} items Items to add to the sync.
+   * @returns {undefined} nothing.
+   */
+  addItems(items) {
+    this.items = _.defaults(items, this.items);
   }
 
-  getBundleItems(bundle) {
-    let items = {};
+  /**
+   * Exclude items next sync execution.
+   * @example
+   * let items = [
+   *   "path/to/dir/in/project"
+   * ]
+   * sync.excludeItems(items);
+   * @param {array} destinationPaths An array of destination paths to exclude
+   *   from the sync.
+   * @returns {undefined} nothing.
+   */
+  excludeItems(destinationPaths) {
+    this.itemsExcluded = this.itemsExcluded.concat(destinationPaths);
+  }
 
-    _.forIn(this.config.sync[bundle], function(item, key) {
-      items[key] = item;
+  /**
+   * Executes syncing of items.
+   * @param {string} buildDirectory Build directory relative to the project
+   *   root. Defaults to build directory defined in aquifer.json.
+   * @param {boolean} forceCopy Set true to force copying over symlinking for
+   *   all items. Defaults to false.
+   * @param {array} bundles Set true to force copying over symlinking for
+   *   all items. Defaults to all sync bundles defined in aquifer.json.
+   * @returns {object} promise object.
+   */
+  execute(buildDirectory, forceCopy, bundles) {
+    this.aquifer.console.log('Beginning sync...');
+    buildDirectory = typeof buildDirectory !== 'undefined' ? buildDirectory : this.config.build.directory;
+    forceCopy = typeof forceCopy !== 'undefined' ? forceCopy : false;
+    bundles = typeof bundles !== 'undefined' ? bundles : Object.keys(this.config.sync);
+    let sync = this;
+    let items = this.items;
+    let itemsExcluded = this.itemsExcluded;
+
+    if (bundles.length > 0) {
+      items = _.defaults(items, this.getBundleItemsMultiple(bundles));
+    }
+
+    _.forIn(items, function(item, key) {
+      if (itemsExcluded.indexOf(item.destination) === -1) {
+        item.source = key;
+        return sync.executeItem(item, buildDirectory, forceCopy);
+      }
+      else {
+        console.log('Excluding: ' + key + ' => ' + item.destination);
+      }
     });
 
-    return items;
+    // Reset items and excluded items.
+    this.items = {};
+    this.itemsExcluded = [];
+    this.aquifer.console.log('Sync complete.');
   }
 
+  /**
+   * Gets items defined in a single sync bundle.
+   * @param {string} bundle Name of the sync bundle.
+   * @returns {object} Sync items defined for the bundle.
+   */
+  getBundleItems(bundle) {
+    return this.config.sync[bundle];
+  }
+
+  /**
+   * Gets items defined in multiple sync bundles.
+   * @param {array} bundles An array of sync bundle names.
+   * @returns {object} Sync items defined for the bundles.
+   */
   getBundleItemsMultiple(bundles) {
     let items = {};
     let sync = this;
 
     bundles.forEach(function(bundle) {
-      console.log(bundle);
       items = _.defaults(items, sync.getBundleItems(bundle));
     });
 
@@ -79,14 +131,25 @@ class Sync {
   /**
    * Executes syncing of a single item.
    * @param {object} item The item to sync.
-   * @param {string} buildDirectory Options to pass to spawn.
-   * @param {string} env The name of the environment on which to invoke.
+   * @param {string} buildDirectory Build directory relative to the project
+   *   root. Defaults to build directory defined in aquifer.json.
+   * @param {boolean} forceCopy Set true to force copying over symlinking for
+   *   all items. Defaults to false.
    * @returns {object} promise object.
    */
   executeItem(item, buildDirectory, forceCopy) {
-    buildDirectory = buildDirectory || this.project.config.build.directory;
+    buildDirectory = typeof buildDirectory !== 'undefined' ? buildDirectory : this.config.build.directory;
+    forceCopy = typeof forceCopy !== 'undefined' ? forceCopy : false;
 
     return new Promise((resolve, reject) => {
+      item.method = item.method || 'copy';
+      item.conflict = item.conflict || 'overwrite';
+
+      if (!item.source) {
+        this.aquifer.console.log('Item with destination ' + item.destination + ' has no source property defined. Skipping.');
+        return false;
+      }
+
       // If destination is the Drupal root and the source is a directory
       // assume we want to copy/sync the contents. Iterate over contents
       // add them to the links array individually.
@@ -99,8 +162,8 @@ class Sync {
           let childItem = {
             source: path.join(item.source, child),
             destination: path.join(item.destination, child),
-            method: item.method || 'copy',
-            conflict: item.conflict || 'overwrite'
+            method: item.method,
+            conflict: item.conflict
           };
 
           return this.executeItem(childItem, buildDirectory, forceCopy);
@@ -108,23 +171,16 @@ class Sync {
       }
       else {
         // Log this to the user.
-        this.aquifer.console.log(((forceCopy || item.method === 'copy') ? 'Copying ' : 'Symlinking ') + item.source + ' => ' + item.destination);
+        this.aquifer.console.log(((forceCopy || item.method === 'copy') ? 'Copying: ' : 'Symlinking: ') + item.source + ' => ' + item.destination);
 
         // Make source and destination paths absolute.
         item.source = path.join(this.project.directory, item.source);
         item.destination = path.join(this.project.getAbsolutePath(buildDirectory), item.destination);
 
-        let destBase = path.dirname(item.destination);
-        let type = 'file';
-
-        if (fs.statSync(item.source).isDirectory()) {
-          type = 'dir';
-        }
-
         // If the source doesn't exist, skip this item.
         if (!fs.existsSync(item.source)) {
           this.aquifer.console.log('Source file does not exist. Skipping: ' + item.source, 'status');
-          reject();
+          return false;
         }
 
         // Handle existing destinations.
@@ -137,15 +193,16 @@ class Sync {
 
             case 'skip':
               this.aquifer.console.log('Destination exists. Conflict set to skip. \nSkipping: ' + item.destination, 'status');
-              reject();
-              break;
+              return false;
 
             default:
-              reject();
+              return false;
           }
         }
 
         // Make sure the destination base path exists.
+        let destBase = path.dirname(item.destination);
+
         if (!fs.existsSync(destBase)) {
           this.aquifer.console.log('Destination directory does not exist. Creating: ' + destBase, 'status');
           fs.mkdirsSync(destBase);
@@ -156,8 +213,14 @@ class Sync {
         if (forceCopy || item.method === 'copy') {
           fs.copySync(item.source, item.destination);
         }
-        // Create symlink
+        // Otherwise create a symlink.
         else {
+          let type = 'file';
+
+          if (fs.statSync(item.source).isDirectory()) {
+            type = 'dir';
+          }
+
           // Change current directory to the destination base path (minus last
           // part of path).
           process.chdir(destBase);
@@ -174,27 +237,6 @@ class Sync {
       }
     })
   }
-
-  executeBundles(bundles, buildDirectory, forceCopy) {
-    let config = this.project.config.sync;
-    let sync = this;
-
-    // TODO: Add promise chain
-
-    bundles.forEach(function(bundle) {
-      _.forIn(config[bundle], function(item, key) {
-        item.source = key;
-        sync.executeItem(item, buildDirectory, forceCopy);
-      });
-    });
-  }
-
-  executeAll(buildDirectory, forceCopy) {
-    let config = this.project.config.sync;
-    let bundles = Object.keys(config);
-    this.executeBundles(bundles, buildDirectory, forceCopy);
-  }
-
 }
 
 module.exports = Sync;

--- a/lib/sync.api.js
+++ b/lib/sync.api.js
@@ -42,47 +42,21 @@ class Sync {
    *   bundles in the sync, false to not include any of the defined sync
    *   bundles. Enter an array of sync bundle names to include only those
    *   bundles in the sync.
+   * @param {string} hook Name of the hook being called. Optional.
+   * @param {string} type Type of items to sync: 'file' or 'dir'. Optional.
    * @returns {object} promise object.
    */
-  execute(buildDirectory, forceCopy, bundles) {
+  execute(buildDirectory, forceCopy, hook, type) {
     buildDirectory = typeof buildDirectory !== 'undefined' ? buildDirectory : this.config.build.directory;
     forceCopy = typeof forceCopy !== 'undefined' ? forceCopy : false;
-    bundles = typeof bundles !== 'undefined' ? bundles : true;
+    hook = typeof hook !== 'undefined' ? hook : false;
+    type = typeof type !== 'undefined' ? type : false;
+
     let sync = this;
-    let items = this.items;
-    let itemsArr = [];
-    let itemsExcluded = this.itemsExcluded;
+    let itemsArr = this.getItems(hook, type);
     let aquiferConsole = this.aquifer.console;
 
-    aquiferConsole.log('Starting sync...');
-
-    // If bundles is true, queue all bundles.
-    if (bundles === true) {
-      bundles = Object.keys(this.config.sync);
-    }
-
-    // Queue defined bundles.
-    if (Array.isArray(bundles) && bundles.length > 0) {
-      items = _.defaults(items, this.getBundleItemsMultiple(bundles));
-    }
-
-    // Iterate items object and add items to the items array for processing.
-    if (!_.isEmpty(items)) {
-      _.forIn(items, function (item, key) {
-        // If item is not excluded, add to the array.
-        if (itemsExcluded.indexOf(item.destination) === -1) {
-          item.source = key;
-          itemsArr.push(item);
-        }
-          // Otherwise skip it and inform the user.
-        else {
-          aquiferConsole.log('Excluding: ' + key + ' => ' + item.destination);
-        }
-      });
-    }
-    else {
-      aquiferConsole.log('Nothing to sync.');
-    }
+    aquiferConsole.log('Starting ' + (hook ? hook + ' ' : '') + 'sync...');
 
     // Process items.
     let itemPromises = itemsArr.map(
@@ -92,10 +66,10 @@ class Sync {
     );
 
     return Promise.all(itemPromises)
-      .then(function (results) {
+      .then(function () {
         // Reset items and excluded items.
         sync.reset();
-        aquiferConsole.log('Sync complete.');
+        aquiferConsole.log((hook ? hook + ' s' : 'S') + 'ync complete.');
       })
       .catch(function (error) {
         sync.reset();
@@ -181,6 +155,7 @@ class Sync {
           case 'overwrite':
             aquiferConsole.log('Destination exists. Conflict set to overwrite. \nOverwriting: ' + item.destination, 'status');
             del.sync(item.destination);
+
             break;
 
           case 'skip':
@@ -196,8 +171,6 @@ class Sync {
               aquiferConsole.log('Unsupported or empty conflict property for: ' + item.source + '. Skipping.', 'status');
             }
         }
-
-        return;
       }
 
       // Make sure the destination base path exists.
@@ -215,10 +188,12 @@ class Sync {
       }
       // Otherwise create a symlink.
       else {
-        let type = 'file';
+        if (typeof item.type == 'undefined') {
+          item.type = 'file';
 
-        if (fs.statSync(item.source).isDirectory()) {
-          type = 'dir';
+          if (fs.statSync(item.source).isDirectory()) {
+            item.type = 'dir';
+          }
         }
 
         // Change current directory to the destination base path (minus last
@@ -227,10 +202,28 @@ class Sync {
 
         // Symlink the relative path of the src from the destination into the
         // basename of the path.
-        fs.symlinkSync(path.relative(destBase, item.source), path.basename(item.destination), type);
+        fs.symlinkSync(path.relative(destBase, item.source), path.basename(item.destination), item.type);
 
         // Change the working directory back to the original.
         process.chdir(this.aquifer.cwd);
+      }
+
+      // Validate required item exists.
+      if (item.required && !fs.existsSync(item.destination)) {
+        reject('Error: Required item failed to sync: ' + item.source);
+      }
+
+      // Validate symlinks and copies.
+      if (fs.existsSync(item.destination)) {
+        let stat = fs.lstatSync(item.destination);
+
+        if ((forceCopy || item.method === 'copy') && stat.isSymbolicLink()) {
+          reject('Error: Item symlinked instead of copied: ' + item.destination);
+        }
+
+        if (!forceCopy && item.method === 'symlink' && !stat.isSymbolicLink()) {
+          reject('Error: Item copied instead of symlinked: ' + item.destination);
+        }
       }
 
       resolve();
@@ -239,27 +232,66 @@ class Sync {
 
   /**
    * Gets items defined in a single sync bundle.
-   * @param {string} bundle Name of the sync bundle.
-   * @returns {object} Sync items defined for the bundle.
+   * @param {string} hook Name of the hook being called. Optional.
+   * @param {string} type Type of items to sync: 'file' or 'dir'. Optional.
+   * @returns {array} Sync items defined for the bundle.
    */
-  getBundleItems(bundle) {
-    return this.config.sync[bundle];
-  }
+  getItems(hook, type) {
+    hook = typeof hook !== 'undefined' ? hook : false;
+    type = typeof type !== 'undefined' ? type : false;
+    let items = this.items;
+    let configItems = this.config.sync;
+    let itemsArr = [];
+    let itemsExcluded = this.itemsExcluded;
+    let aquiferConsole = this.aquifer.console;
 
-  /**
-   * Gets items defined in multiple sync bundles.
-   * @param {array} bundles An array of sync bundle names.
-   * @returns {object} Sync items defined for the bundles.
-   */
-  getBundleItemsMultiple(bundles) {
-    let items = {};
-    let sync = this;
+    // Combine items from configuration with added items.
+    items = _.defaults(items, configItems);
 
-    bundles.forEach(function(bundle) {
-      items = _.defaults(items, sync.getBundleItems(bundle));
-    });
+    // Iterate items object and add items to the items array for processing.
+    if (!_.isEmpty(items)) {
+      _.forIn(items, function (item, key) {
+        // If a hook is specified and item does not have that hook.
+        if (hook && (item.hook == 'undefined' || item.hook !== hook)) {
+          return;
+        }
 
-    return items;
+        if (type) {
+          if (item.type == 'undefined') {
+            let source = path.join(this.project.directory, key);
+
+            if (fs.existsSync(source)) {
+              let type = 'file';
+
+              if (fs.statSync(source).isDirectory()) {
+                type = 'dir';
+              }
+
+              item.type = type;
+            }
+            else {
+              item.type = false;
+            }
+          }
+
+          if (!item.type || item.type !== type) {
+            return;
+          }
+        }
+
+        // If item is not excluded, add to the array.
+        if (itemsExcluded.indexOf(item.destination) === -1) {
+          item.source = key;
+          itemsArr.push(item);
+        }
+        // Otherwise skip it and inform the user.
+        else {
+          aquiferConsole.log('Excluding: ' + key + ' => ' + item.destination);
+        }
+      });
+    }
+
+    return itemsArr;
   }
 
   /**

--- a/lib/sync.api.js
+++ b/lib/sync.api.js
@@ -43,10 +43,10 @@ class Sync {
    * @returns {object} promise object.
    */
   execute(buildDirectory, forceCopy, hook, type) {
-    buildDirectory = typeof buildDirectory !== 'undefined' ? buildDirectory : this.config.build.directory;
-    forceCopy = typeof forceCopy !== 'undefined' ? forceCopy : false;
-    hook = typeof hook !== 'undefined' ? hook : false;
-    type = typeof type !== 'undefined' ? type : false;
+    buildDirectory = buildDirectory || this.config.build.directory;
+    forceCopy = forceCopy || false;
+    hook = hook || false;
+    type = type || false;
 
     let sync = this;
     let itemsArr = this.getItems(hook, type);
@@ -82,14 +82,18 @@ class Sync {
    * @returns {object} promise object.
    */
   executeItem(item, buildDirectory, forceCopy) {
-    buildDirectory = typeof buildDirectory !== 'undefined' ? buildDirectory : this.config.build.directory;
+    buildDirectory = buildDirectory || this.config.build.directory;
     forceCopy = typeof forceCopy !== 'undefined' ? forceCopy : true;
 
     return new Promise((resolve, reject) => {
-      item.method = typeof item.method !== 'undefined' ? item.method : 'copy';
-      item.conflict = typeof item.conflict !== 'undefined' ? item.conflict : 'overwrite';
-      item.required = typeof item.required !== 'undefined' ? item.required : false;
-      item.contents = typeof item.contents !== 'undefined' ? item.contents : false;
+      let defaultItem = {
+        method: 'copy',
+        conflict: 'overwrite',
+        required: false,
+        contents: false
+      };
+
+      _.defaults(item, defaultItem);
 
       // If item.destination is the build directory and item.source is a
       // directory and item.contents is false, prevent the build directory from
@@ -100,7 +104,7 @@ class Sync {
       }
 
       // Item must have a source property defined.
-      if (typeof item.source === 'undefined' || !item.source) {
+      if (!item.hasOwnProperty('source') || !item.source) {
         reject('Item with destination ' + item.destination + ' has no source defined. Skipping.');
         return;
       }
@@ -190,7 +194,7 @@ class Sync {
       }
       // Otherwise create a symlink.
       else {
-        if (typeof item.type == 'undefined') {
+        if (!item.hasOwnProperty('type')) {
           item.type = 'file';
 
           if (fs.statSync(item.source).isDirectory()) {
@@ -239,8 +243,8 @@ class Sync {
    * @returns {array} Sync items defined for the bundle.
    */
   getItems(hook, type) {
-    hook = typeof hook !== 'undefined' ? hook : false;
-    type = typeof type !== 'undefined' ? type : false;
+    hook = hook || false;
+    type = type || false;
     let items = this.items;
     let configItems = this.config.sync;
     let itemsArr = [];

--- a/lib/sync.api.js
+++ b/lib/sync.api.js
@@ -86,7 +86,6 @@ class Sync {
     forceCopy = typeof forceCopy !== 'undefined' ? forceCopy : true;
 
     return new Promise((resolve, reject) => {
-      let aquiferConsole = this.aquifer.console;
       item.method = typeof item.method !== 'undefined' ? item.method : 'copy';
       item.conflict = typeof item.conflict !== 'undefined' ? item.conflict : 'overwrite';
       item.required = typeof item.required !== 'undefined' ? item.required : false;
@@ -246,7 +245,6 @@ class Sync {
     let configItems = this.config.sync;
     let itemsArr = [];
     let itemsExcluded = this.itemsExcluded;
-    let aquiferConsole = this.aquifer.console;
 
     // Combine items from configuration with added items.
     items = _.defaults(items, configItems);

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "lodash": "^3.6.0",
     "parse-spawn-args": "^1.0.2",
     "path": "^0.11.14",
-    "replace": "^0.3.0",
     "ssh2": "^0.4.13",
     "touch": "0.0.3",
     "untildify": "^2.1.0"

--- a/src/d7/aquifer.default.json
+++ b/src/d7/aquifer.default.json
@@ -43,27 +43,14 @@
       "type": "dir",
       "hook": "postBuild"
     },
-    "settings/settings.php": {
-      "destination": "sites/default/settings.php",
+    "settings": {
+      "destination": "sites/default",
       "method": "symlink",
       "conflict": "overwrite",
       "type": "file",
       "hook": "postBuild",
-      "required": true
-    },
-    "settings/secret.settings.php": {
-      "destination": "sites/default/secret.settings.php",
-      "method": "symlink",
-      "conflict": "overwrite",
-      "type": "file",
-      "hook": "postBuild"
-    },
-    "settings/local.settings.php": {
-      "destination": "sites/default/local.settings.php",
-      "method": "symlink",
-      "conflict": "overwrite",
-      "type": "file",
-      "hook": "postBuild"
+      "required": true,
+      "contents": true
     }
   },
   "run": {

--- a/src/d7/aquifer.default.json
+++ b/src/d7/aquifer.default.json
@@ -7,49 +7,63 @@
     "makeFile": "drupal.make.yml"
   },
   "sync": {
-    "directories": {
-      "root": {
-        "destination": "",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "modules/custom": {
-        "destination": "sites/all/modules/custom",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "modules/features": {
-        "destination": "sites/all/modules/features",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "themes/custom": {
-        "destination": "sites/all/themes/custom",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "files": {
-        "destination": "sites/default/files",
-        "method": "symlink",
-        "conflict": "overwrite"
-      }
+    "root": {
+      "destination": "",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "dir",
+      "hook": "postBuild",
+      "required": true
+    },
+    "modules/custom": {
+      "destination": "sites/all/modules/custom",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "dir",
+      "hook": "postBuild"
+    },
+    "modules/features": {
+      "destination": "sites/all/modules/features",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "dir",
+      "hook": "postBuild"
+    },
+    "themes/custom": {
+      "destination": "sites/all/themes/custom",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "dir",
+      "hook": "postBuild"
     },
     "files": {
-      "settings/settings.php": {
-        "destination": "sites/default/settings.php",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "settings/secret.settings.php": {
-        "destination": "sites/default/secret.settings.php",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "settings/local.settings.php": {
-        "destination": "sites/default/local.settings.php",
-        "method": "symlink",
-        "conflict": "overwrite"
-      }
+      "destination": "sites/default/files",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "dir",
+      "hook": "postBuild"
+    },
+    "settings/settings.php": {
+      "destination": "sites/default/settings.php",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "file",
+      "hook": "postBuild",
+      "required": true
+    },
+    "settings/secret.settings.php": {
+      "destination": "sites/default/secret.settings.php",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "file",
+      "hook": "postBuild"
+    },
+    "settings/local.settings.php": {
+      "destination": "sites/default/local.settings.php",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "file",
+      "hook": "postBuild"
     }
   },
   "run": {

--- a/src/d7/aquifer.default.json
+++ b/src/d7/aquifer.default.json
@@ -13,7 +13,8 @@
       "conflict": "overwrite",
       "type": "dir",
       "hook": "postBuild",
-      "required": true
+      "required": true,
+      "contents": true
     },
     "modules/custom": {
       "destination": "sites/all/modules/custom",

--- a/src/d7/aquifer.default.json
+++ b/src/d7/aquifer.default.json
@@ -21,28 +21,32 @@
       "method": "symlink",
       "conflict": "overwrite",
       "type": "dir",
-      "hook": "postBuild"
+      "hook": "postBuild",
+      "required": true
     },
     "modules/features": {
       "destination": "sites/all/modules/features",
       "method": "symlink",
       "conflict": "overwrite",
       "type": "dir",
-      "hook": "postBuild"
+      "hook": "postBuild",
+      "required": true
     },
     "themes/custom": {
       "destination": "sites/all/themes/custom",
       "method": "symlink",
       "conflict": "overwrite",
       "type": "dir",
-      "hook": "postBuild"
+      "hook": "postBuild",
+      "required": true
     },
     "files": {
       "destination": "sites/default/files",
       "method": "symlink",
       "conflict": "overwrite",
       "type": "dir",
-      "hook": "postBuild"
+      "hook": "postBuild",
+      "required": true
     },
     "settings": {
       "destination": "sites/default",

--- a/src/d8/aquifer.default.json
+++ b/src/d8/aquifer.default.json
@@ -7,44 +7,56 @@
     "makeFile": "drupal.make.yml"
   },
   "sync": {
-    "directories": {
-      "root": {
-        "destination": "",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "modules/custom": {
-        "destination": "modules/custom",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "themes/custom": {
-        "destination": "themes/custom",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "files": {
-        "destination": "sites/default/files",
-        "method": "symlink",
-        "conflict": "overwrite"
-      }
+    "root": {
+      "destination": "",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "dir",
+      "hook": "postBuild",
+      "required": true
+    },
+    "modules/custom": {
+      "destination": "modules/custom",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "dir",
+      "hook": "postBuild"
+    },
+    "themes/custom": {
+      "destination": "themes/custom",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "dir",
+      "hook": "postBuild"
     },
     "files": {
-      "settings/settings.php": {
-        "destination": "sites/default/settings.php",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "settings/secret.settings.php": {
-        "destination": "sites/default/secret.settings.php",
-        "method": "symlink",
-        "conflict": "overwrite"
-      },
-      "settings/local.settings.php": {
-        "destination": "sites/default/local.settings.php",
-        "method": "symlink",
-        "conflict": "overwrite"
-      }
+      "destination": "sites/default/files",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "dir",
+      "hook": "postBuild"
+    },
+    "settings/settings.php": {
+      "destination": "sites/default/settings.php",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "file",
+      "hook": "postBuild",
+      "required": true
+    },
+    "settings/secret.settings.php": {
+      "destination": "sites/default/secret.settings.php",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "file",
+      "hook": "postBuild"
+    },
+    "settings/local.settings.php": {
+      "destination": "sites/default/local.settings.php",
+      "method": "symlink",
+      "conflict": "overwrite",
+      "type": "file",
+      "hook": "postBuild"
     }
   },
   "run": {

--- a/src/d8/aquifer.default.json
+++ b/src/d8/aquifer.default.json
@@ -21,21 +21,24 @@
       "method": "symlink",
       "conflict": "overwrite",
       "type": "dir",
-      "hook": "postBuild"
+      "hook": "postBuild",
+      "required": true
     },
     "themes/custom": {
       "destination": "themes/custom",
       "method": "symlink",
       "conflict": "overwrite",
       "type": "dir",
-      "hook": "postBuild"
+      "hook": "postBuild",
+      "required": true
     },
     "files": {
       "destination": "sites/default/files",
       "method": "symlink",
       "conflict": "overwrite",
       "type": "dir",
-      "hook": "postBuild"
+      "hook": "postBuild",
+      "required": true
     },
     "settings": {
       "destination": "sites/default",

--- a/src/d8/aquifer.default.json
+++ b/src/d8/aquifer.default.json
@@ -13,7 +13,8 @@
       "conflict": "overwrite",
       "type": "dir",
       "hook": "postBuild",
-      "required": true
+      "required": true,
+      "contents": true
     },
     "modules/custom": {
       "destination": "modules/custom",

--- a/src/d8/aquifer.default.json
+++ b/src/d8/aquifer.default.json
@@ -36,27 +36,14 @@
       "type": "dir",
       "hook": "postBuild"
     },
-    "settings/settings.php": {
-      "destination": "sites/default/settings.php",
+    "settings": {
+      "destination": "sites/default",
       "method": "symlink",
       "conflict": "overwrite",
       "type": "file",
       "hook": "postBuild",
-      "required": true
-    },
-    "settings/secret.settings.php": {
-      "destination": "sites/default/secret.settings.php",
-      "method": "symlink",
-      "conflict": "overwrite",
-      "type": "file",
-      "hook": "postBuild"
-    },
-    "settings/local.settings.php": {
-      "destination": "sites/default/local.settings.php",
-      "method": "symlink",
-      "conflict": "overwrite",
-      "type": "file",
-      "hook": "postBuild"
+      "required": true,
+      "contents": true
     }
   },
   "run": {


### PR DESCRIPTION
Abstracts syncing operations in build to a new Sync API. It has become clear to me that it'll be useful to facilitate syncing of items in more places that just after the build is scaffolded, like pre-build for example. This API creates a standardized way of initiating syncing of items.

This refactors a significant portion of the build process. Pay special attention to my somewhat lacking understanding of Promises and my code using them herein 😬 .

**To test:**
- [x] Run `aquifer create test -d 8 && cd test`
- [x] Run `aquifer build`
- [x] Verify that the `/build` directory contains a Drupal site and the synced directories and files defined in `aquifer.json` are synced appropriately.
- [x] Run `mkdir -p config/base`
- [x] Add the following to the `sync.directories` object in `aquifer.json`:

```
"config": {
  "destination": "sites/default/config",
  "method": "symlink",
  "conflict": "overwrite",
  "type": "dir",
  "hook": "preBuild"
}
```
- [x] Run `aquifer build` 
- [x] Verify console output shows this getting synced during the preBuild sync operation.
- [x] Verify the new `/config` directory is symlinked into `/build/sites/default`.
- [x] Run `touch root/LICENSE.txt`
- [x] Add the following to the `sync.files` object in `aquifer.json`:

```
"root/LICENSE.txt": {
  "destination": "LICENSE.txt",
  "method": "copy",
  "conflict": "overwrite",
  "type": "file",
  "hook": "postBuild"
}
```
- [x] Run `aquifer build`
- [x] Verify console output shows this getting synced during the postBuild sync operation.
- [x] Verify `/build/LICENSE.txt` is overwritten by a copy (not symlink) or your blank file.
- [x] In `aquifer.json` change the conflict value to skip for `root/LICENSE.txt`.
- [x] Run `aquifer build` and verify `/build/LICENSE.txt` is has been left alone.

We also need to verify this is working with aquifer-git's `addLinks` and `excludeLinks` options so it would be great if someone else can test this that has `aquifer-git` configured for a site:
- [x] Install `aquifer-git` in your project ensuring it is on the `1.0.0` branch.
- [x] Edit your `aquifer.json` file to include `aquifer-git` configuration:
  
  ```
  "extensions": {
    "aquifer-git": {
      "source": "aquifer-git",
      "remote": "user@agitrepositoryhost.com:repositoryname.git",
      "branch": "master",
      "folder": "docroot",
      "name": "Deploy Bot",
      "email": "deploybot@aquifer.io",
      "excludeLinks": ["sites/default/files"],
      "addLinks": [
        {
          "src": "pizza",
          "dest": "pizza",
          "type": "dir"
        }
      ],
      "delPatterns": ["*", "!.git"]
    }
  }
  ```
- [x] Add a file to the files directory:
  
  ```
  touch files/beer.js
  ```
- [x] Add the pizza directory you just defined to the project root:
  
  ```
  mkdir pizza && touch pizza/pepperoni.txt
  ```
- [x] Run `aquifer deploy-git --debug`
- [x] Inspect the `aquifer-git-XXXXXXX` directory that is left behind.
- [x] Verify that `sites/default/files` does not exist or if it does that it has not been copied (i.e. does not contain `beer.js`)
- [x] Verify that the `pizza` directory has been copied.

**Test "contents" property**
- [x] Add a new directory and files that will copy the source contents only:
  
  ```
  mkdir beer && touch beer/ipa.txt && touch beer/stout.txt
  ```
- [x] Add the directory to the sync config in `aquifer.json` with the "contents" property set to true:

```
"beer": {
  "destination": "sites/default",
  "method": "symlink",
  "conflict": "overwrite",
  "type": "dir",
  "hook": "postBuild",
  "contents": true
}
```
- [x] Also add the "contents" property to the existing "root" sync item (or the build will fail):

```
"root": {
  "destination": "",
  "method": "symlink",
  "conflict": "overwrite",
  "type": "dir",
  "hook": "postBuild",
  "required": true,
  "contents": true
},
```
- [x] Run `aquifer build`
- [x] Verify that `ipa.txt` and `stout.txt` were copied into `/sites/default`.
