### PR TITLE
Add build command options to config

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -105,6 +105,7 @@ class Build {
 
       let command = '';
       let commandOptions = {};
+      let buildOptions = typeof project.config.build.options !== 'undefined' ? project.config.build.options : [];
 
       // In the future defer to a "build plugin" to run the command needed.
       if (this.options.buildMethod === 'drush make') {
@@ -116,8 +117,16 @@ class Build {
         commandOptions = {cwd: this.destination};
       }
 
+      // Append options to command.
+      if (buildOptions.length) {
+        buildOptions.forEach(function (option) {
+          console.log(command);
+          command += ' ' + option;
+        });
+      }
+
       // Run build command.
-      this.aquifer.console.log('Executing ' + this.options.buildMethod + '...');
+      this.aquifer.console.log('Executing: ' + command);
       run.invoke(command, commandOptions)
       .then(() => {
         // Copy or symlink custom code files and directories.

--- a/src/d7/aquifer.default.json
+++ b/src/d7/aquifer.default.json
@@ -4,7 +4,8 @@
   "build": {
     "method": "drush make",
     "directory": "build",
-    "makeFile": "drupal.make.yml"
+    "makeFile": "drupal.make.yml",
+    "options": []
   },
   "sync": {
     "directories": {

--- a/src/d8/aquifer.default.json
+++ b/src/d8/aquifer.default.json
@@ -4,7 +4,8 @@
   "build": {
     "method": "drush make",
     "directory": "build",
-    "makeFile": "drupal.make.yml"
+    "makeFile": "drupal.make.yml",
+    "options": []
   },
   "sync": {
     "directories": {


### PR DESCRIPTION
Allows build command options to be configured in aquifer.json.

My use case for this is I needed the `--ignore-platform-reqs` flag to be set when `composer install` is invoked.

**To test:**
- 
