### PR TITLE
Version autoselection

### DIFF
--- a/bin/aquifer.js
+++ b/bin/aquifer.js
@@ -20,6 +20,7 @@ const Console = require('../lib/console.api');
 const Project = require('../lib/project.api');
 const Build = require('../lib/build.api');
 const Run = require('../lib/run.api');
+const Npm = require('../lib/npm.api');
 const Extension = require('../lib/extension.api');
 const Environment = require('../lib/environment.api');
 
@@ -28,6 +29,7 @@ AquiferAPI.prototype.api = {
   project: Project,
   build: Build,
   run: Run,
+  npm: Npm,
   extension: Extension,
   environment: Environment
 }

--- a/lib/aquifer.api.js
+++ b/lib/aquifer.api.js
@@ -6,7 +6,11 @@
 'use strict';
 
 // Load dependencies.
+const _ = require('lodash');
 const fs = require('fs-extra');
+const spawn = require('child_process').spawn;
+const jsonFile = require('jsonfile');
+const path = require('path');
 
 /**
  * Constructs a main Aquifer project.
@@ -74,18 +78,44 @@ class Aquifer {
 
       // Traverse cwd, and find the aquifer project dir. If one does not exist
       // in the current path, the framework is not initialized.
+      this.getProjectDir()
+      .then(() => {
+        if (this.projectDir) {
+          this.initialized = true;
+        }
+        return this.getConfig();
+      })
+      .then(() => {
+        return this.switchVersion();
+      })
+      .then(() => {
+        if (this.initialized) {
+          this.project = new this.api.project(this);
+        }
+        resolve();
+      })
+      .catch((reason) => {
+        reject(reason);
+      })
+    });
+  }
+
+  /**
+   * Find the current Aquifer project root.
+   * @returns {object} promise object.
+   */
+  getProjectDir() {
+    return new Promise((resolve, reject) => {
+      // Traverse cwd, and find the aquifer project dir.
       let dir = this.cwd;
       while (this.projectDir === false && dir.length > 0) {
         if (fs.existsSync(dir + '/aquifer.json')) {
-          this.initialized = true;
           this.projectDir = dir;
-          this.project = new this.api.project(this);
         }
         else {
           dir = dir.substring(0, dir.lastIndexOf('/'));
         }
       }
-
       resolve();
     });
   }
@@ -153,6 +183,87 @@ class Aquifer {
 
       resolve();
     })
+  }
+
+  /**
+   * Get initial project configuration.
+   * @returns {object} promise object.
+   */
+  getConfig() {
+    return new Promise((resolve, reject) => {
+      // If this project is initialized, load the JSON path.
+      if (this.initialized) {
+        // Calculate paths to json, and source directory.
+        let jsonPath = path.join(this.projectDir, 'aquifer.json');
+        let localJsonPath = path.join(this.projectDir, 'aquifer.local.json');
+
+        this.initialConfig = jsonFile.readFileSync(jsonPath);
+
+        // Extend config with aquifer.local.json.
+        if (fs.existsSync(localJsonPath)) {
+          this.initialConfig = _.defaultsDeep(jsonFile.readFileSync(localJsonPath), this.initialConfig);
+        }
+      }
+
+      // If this is a new (uninitialized) project, load the default json.
+      else {
+        this.initialConfig = jsonFile.readFileSync(path.join(this.srcDir, 'aquifer.default.json'));
+
+        // If a config json path was passed in, extend the default.
+        if (configJsonPath) {
+          var configJson = jsonFile.readFileSync(configJsonPath);
+          _.merge(this.initialConfig, configJson);
+        }
+      }
+
+      resolve();
+    })
+  }
+
+  /**
+   * Redirects execution to the proper version of aquifer.
+   * @returns {object} promise object.
+   */
+  switchVersion() {
+    return new Promise((resolve, reject) => {
+      // No need to switch aquifer versions if we don't have an aquifer project, yet.
+      if (!this.initialized) {
+        resolve();
+        return;
+      }
+
+      if (!this.initialConfig.hasOwnProperty('version')) {
+        this.console.log('You have not specified an aquifer version in aquifer.json. Using the default installed version: ' + this.version, 'warning');
+        resolve();
+        return;
+      }
+
+      if (this.initialConfig.version === this.version) {
+        resolve();
+        return;
+      }
+
+      let newAquifer = new this.api.npm(this, 'aquifer', 'aquifer@' + this.initialConfig.version);
+
+      if (!newAquifer.installed) {
+        this.console.log('Aquifer ' + this.initialConfig.version + ' is not installed. Installing now...');
+      }
+
+      newAquifer.install()
+      .then(() => {
+        let command = newAquifer.path + '/../.bin/aquifer';
+
+        // Execute aquifer with the proper version.
+        let p = spawn(command, process.argv.slice(2), {stdio: 'inherit'});
+
+        p.on('close', () => {
+          process.exit();
+        })
+      })
+      .catch((reason) => {
+        reject(reason);
+      });
+    });
   }
 }
 

--- a/lib/aquifer.api.js
+++ b/lib/aquifer.api.js
@@ -244,16 +244,10 @@ class Aquifer {
 
         // Since the child aquifer module is installed, if the child module and
         // this current instance of aquifer have the same directory, then we are
-        // running a chained instance of aquifer.
-        if (aquiferDir === newAquiferDir) {
-          // Handle mismatched version and source properties.
-          if (this.initialConfig.version !== this.version) {
-            reject('You have specified a version of aquifer that does not match the version that was installed. You probably have misconfigured source or version properties in your aquifer.json file.');
-            return;
-          }
-
-          // Stop here if we're already running a chained instance of aquifer.
-          resolve();
+        // running a chained instance of aquifer. If that chained instance
+        // doesn't have a matching version property, we have a problem.
+        if (aquiferDir === newAquiferDir && this.initialConfig.version !== this.version) {
+          reject('You have specified a version of aquifer that does not match the version that was installed. You probably have misconfigured source or version properties in your aquifer.json file.');
           return;
         }
       }

--- a/lib/aquifer.api.js
+++ b/lib/aquifer.api.js
@@ -252,13 +252,27 @@ class Aquifer {
         }
       }
 
-      // Let the user know we'll be installing the specified version of aquifer now.
-      if (!newAquifer.installed) {
-        this.console.log('Aquifer ' + this.initialConfig.version + ' is not installed. Installing now...');
-      }
+      // Install the right version of Aquifer.
+      let installAquifer = new Promise((installResolve, installReject) => {
+        // Return early if Aquifer is already installed.
+        if (newAquifer.installed) {
+          installResolve();
+          return;
+        }
 
-      newAquifer.install()
-      .then(() => {
+        // Let the user know we'll be installing the specified version of aquifer now.
+        this.console.log('Aquifer ' + this.initialConfig.version + ' is not installed. Installing now...');
+
+        newAquifer.install()
+        .then(() => {
+          installResolve();
+        })
+        .catch((reason) => {
+          installReject(reason);
+        })
+      });
+
+      installAquifer.then(() => {
         let command = path.join(newAquifer.path, '../.bin/aquifer');
 
         // Execute aquifer with the proper version.

--- a/lib/aquifer.api.js
+++ b/lib/aquifer.api.js
@@ -234,15 +234,38 @@ class Aquifer {
         return;
       }
 
-      let newAquifer = new this.api.npm(this, 'aquifer', 'aquifer@' + this.initialConfig.version);
+      let source = this.initialConfig.source || 'aquifer@' + this.initialConfig.version;
 
+      let newAquifer = new this.api.npm(this, 'aquifer', source);
+
+      if (newAquifer.installed) {
+        let newAquiferDir = fs.realpathSync(path.join(newAquifer.path));
+        let aquiferDir = fs.realpathSync(path.join(path.dirname(module.parent.filename), '..'));
+
+        // Since the child aquifer module is installed, if the child module and
+        // this current instance of aquifer have the same directory, then we are
+        // running a chained instance of aquifer.
+        if (aquiferDir === newAquiferDir) {
+          // Handle mismatched version and source properties.
+          if (this.initialConfig.version !== this.version) {
+            reject('You have specified a version of aquifer that does not match the version that was installed. You probably have misconfigured source or version properties in your aquifer.json file.');
+            return;
+          }
+
+          // Stop here if we're already running a chained instance of aquifer.
+          resolve();
+          return;
+        }
+      }
+
+      // Let the user know we'll be installing the specified version of aquifer now.
       if (!newAquifer.installed) {
         this.console.log('Aquifer ' + this.initialConfig.version + ' is not installed. Installing now...');
       }
 
       newAquifer.install()
       .then(() => {
-        let command = newAquifer.path + '/../.bin/aquifer';
+        let command = path.join(newAquifer.path, '../.bin/aquifer');
 
         // Execute aquifer with the proper version.
         let p = spawn(command, process.argv.slice(2), {stdio: 'inherit'});

--- a/lib/aquifer.api.js
+++ b/lib/aquifer.api.js
@@ -191,6 +191,8 @@ class Aquifer {
    */
   getConfig() {
     return new Promise((resolve, reject) => {
+      this.initialConfig = {};
+
       // If this project is initialized, load the JSON path.
       if (this.initialized) {
         // Calculate paths to json, and source directory.
@@ -202,17 +204,6 @@ class Aquifer {
         // Extend config with aquifer.local.json.
         if (fs.existsSync(localJsonPath)) {
           this.initialConfig = _.defaultsDeep(jsonFile.readFileSync(localJsonPath), this.initialConfig);
-        }
-      }
-
-      // If this is a new (uninitialized) project, load the default json.
-      else {
-        this.initialConfig = jsonFile.readFileSync(path.join(this.srcDir, 'aquifer.default.json'));
-
-        // If a config json path was passed in, extend the default.
-        if (configJsonPath) {
-          var configJson = jsonFile.readFileSync(configJsonPath);
-          _.merge(this.initialConfig, configJson);
         }
       }
 

--- a/lib/extension.api.js
+++ b/lib/extension.api.js
@@ -70,6 +70,9 @@ class Extension {
         this.loadConfig();
         resolve();
       })
+      .catch((reason) => {
+        reject(reason);
+      });
     })
   }
 

--- a/lib/extension.api.js
+++ b/lib/extension.api.js
@@ -43,6 +43,9 @@ class Extension {
       this.source = source || this.name;
     }
 
+    // Construct the npm module instance.
+    this.npmModule = new this.aquifer.api.npm(this.aquifer, this.name, this.source);
+
     // Use the source value to determine whether the extension is local.
     this.isLocal = this.pathExists(this.source);
   }
@@ -54,7 +57,7 @@ class Extension {
   install() {
     return new Promise((resolve, reject) => {
       // Download this extension.
-      this.download()
+      this.npmModule.install()
 
       // Update extensions object in aquifer.json.
       .then(() => {
@@ -76,13 +79,10 @@ class Extension {
    */
   uninstall() {
     return new Promise((resolve, reject) => {
-      // npm install extension.
-      let p = exec('cd ' + path.join(this.aquifer.project.directory, '.aquifer') + ' && npm uninstall --save ' + this.name, (error, stdout, stderr) => {
-        if (error) {
-          reject('Could not remove ' + this.name + ': ' + error);
-          return;
-        }
+      // npm uninstall extension.
+      this.npmModule.uninstall()
 
+      .then(() => {
         // Remove configuration from aquifer.json.
         let extensions = this.aquifer.project.config.extensions;
         delete extensions[this.name];
@@ -93,9 +93,6 @@ class Extension {
         this.loadConfig();
         resolve();
       });
-
-      p.stdout.pipe(process.stdout)
-      p.stderr.pipe(process.stdout);
     })
   }
 
@@ -118,7 +115,7 @@ class Extension {
         return;
       }
 
-      let extension = require(this.path)(this.aquifer, this.config) || false;
+      let extension = this.npmModule.load([this.aquifer, this.config]) || false;
       resolve(extension);
     })
   };
@@ -129,32 +126,14 @@ class Extension {
    */
   download() {
     return new Promise((resolve, reject) => {
-      // Set command to link if local.
-      let command = this.isLocal ? 'link' : 'install';
-      let vendor  = path.join(this.aquifer.project.directory, '.aquifer');
+      this.npmModule.install()
 
-      // If the .aquifer directory does not exist yet, create it.
-      if (!this.pathExists(vendor)) {
-        // Make the directory.
-        fs.mkdirSync(vendor);
-
-        // Copy src/package.json into .aquifer/package.json.
-        fs.copySync(path.join(this.aquifer.project.srcDir, 'package.json'), path.join(vendor, 'package.json'));
-      }
-
-      // Download the extensions.
-      let p = exec('cd ' + vendor + ' && npm ' + command + ' --save ' + this.source, (error, stdout, stderr) => {
-        if (error) {
-          reject('Could not download ' + this.name + ': ' + error);
-          return;
-        }
-
+      // Reload config.
+      .then(() => {
+        this.loadConfig();
         resolve();
-      });
-
-      p.stdout.pipe(process.stdout)
-      p.stderr.pipe(process.stdout);
-    })
+      })
+    });
   }
 
   /**

--- a/lib/npm.api.js
+++ b/lib/npm.api.js
@@ -1,0 +1,136 @@
+/**
+ * @file
+ * Defines an npm api for the aquifer cli.
+ */
+
+'use strict';
+
+// Load dependencies.
+const exec = require('child_process').exec;
+const path = require('path');
+const fs = require('fs-extra');
+
+/**
+ * Constructs the npm API for Aquifer.
+ *
+ * @class
+ * @classdesc Contains npm API for Aquifer.
+ */
+class Npm {
+
+  /**
+   * Scaffolds properties and initializes class.
+   * @param {object} Aquifer active instance of Aquifer.
+   * @param {string} name machine-friendly name of the module.
+   * @param {string} source module source. This could be any value recognized by `npm install <source>`.
+   * @returns {undefined} nothing.
+   */
+  constructor(Aquifer, name, source) {
+    this.aquifer = Aquifer;
+    this.name = name || null;
+
+    this.path = path.join(this.aquifer.projectDir, '.aquifer/node_modules/' + this.name);
+    this.installed = this.pathExists(this.path) ? true : false;
+    this.source = source || this.name;
+
+    // Use the source value to determine whether the module is local.
+    this.isLocal = this.pathExists(this.source);
+  }
+
+  /**
+   * Uninstalls the module.
+   * @returns {object} promise object.
+   */
+  uninstall() {
+    return new Promise((resolve, reject) => {
+      // npm uninstall module.
+      let p = exec('cd ' + path.join(this.aquifer.projectDir, '.aquifer') + ' && npm uninstall --save ' + this.name, (error, stdout, stderr) => {
+        if (error) {
+          reject('Could not remove ' + this.name + ': ' + error);
+          return;
+        }
+        resolve();
+      });
+
+      p.stdout.pipe(process.stdout)
+      p.stderr.pipe(process.stdout);
+    })
+  }
+
+  /**
+   * Loads an npm module.
+   * @param {array} args array of arguments to pass to the module constructor.
+   * @returns {object} promise object.
+   */
+  load(args) {
+    return new Promise((resolve, reject) => {
+      if (!this.installed) {
+        reject('The ' + this.name + ' module has not been installed.');
+        return;
+      }
+
+      args = args || [];
+
+      let npmModule = require(this.path)(...args) || false;
+      resolve(npmModule);
+    })
+  };
+
+  /**
+   * Installs this module.
+   * @returns {object} promise object.
+   */
+  install() {
+    return new Promise((resolve, reject) => {
+      // Do not install a module that is already installed.
+      if (this.installed) {
+        resolve();
+        return;
+      }
+
+      // Set command to link if local.
+      let command = this.isLocal ? 'link' : 'install';
+      let vendor  = path.join(this.aquifer.projectDir, '.aquifer');
+
+      // If the .aquifer directory does not exist yet, create it.
+      if (!this.pathExists(vendor)) {
+        // Make the directory.
+        fs.mkdirSync(vendor);
+
+        // Copy src/package.json into .aquifer/package.json.
+        fs.copySync(path.join(this.aquifer.project.srcDir, 'package.json'), path.join(vendor, 'package.json'));
+      }
+
+      // Install the module.
+      let p = exec('cd ' + vendor + ' && npm ' + command + ' --save ' + this.source, (error, stdout, stderr) => {
+        if (error) {
+          reject('Could not install ' + this.name + ': ' + error);
+          return;
+        }
+
+        resolve();
+      });
+
+      p.stdout.pipe(process.stdout)
+      p.stderr.pipe(process.stdout);
+    })
+  }
+
+  /**
+   * Determines whether or not a path exists.
+   * @param {string} toCheck path for which this function will check for existence.
+   * @returns {boolean} true if path exists, false if else.
+   */
+  pathExists(toCheck) {
+    try {
+      fs.statSync(toCheck);
+    }
+    catch (error) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+module.exports = Npm;

--- a/lib/npm.api.js
+++ b/lib/npm.api.js
@@ -49,6 +49,9 @@ class Npm {
           reject('Could not remove ' + this.name + ': ' + error);
           return;
         }
+
+        this.installed = false;
+
         resolve();
       });
 
@@ -107,6 +110,8 @@ class Npm {
           reject('Could not install ' + this.name + ': ' + error);
           return;
         }
+
+        this.installed = true;
 
         resolve();
       });

--- a/lib/npm.api.js
+++ b/lib/npm.api.js
@@ -87,7 +87,7 @@ class Npm {
     return new Promise((resolve, reject) => {
       // Do not install a module that is already installed.
       if (this.installed) {
-        resolve();
+        reject('The ' + this.name + ' module is already installed.');
         return;
       }
 

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -57,6 +57,20 @@ class Project {
     return new Promise((resolve, reject) => {
       let jsonPath = path.join(directory, 'aquifer.json');
 
+      // Set up configuration for new projects.
+      if (!this.aquifer.initialized) {
+        this.config = jsonFile.readFileSync(path.join(this.srcDir, 'aquifer.default.json'));
+
+        // Set the version property.
+        this.config.version = this.aquifer.version;
+
+        // If a config json path was passed in, extend the default.
+        if (configJsonPath) {
+          let configJson = jsonFile.readFileSync(configJsonPath);
+          _.merge(this.config, configJson);
+        }
+      }
+
       // Default directory to Aquifer.projectDir.
       this.directory = directory = directory || this.aquifer.projectDir;
 

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -62,7 +62,7 @@ class Project {
         this.config = jsonFile.readFileSync(path.join(this.srcDir, 'aquifer.default.json'));
 
         // Set the version property.
-        this.config.version = this.aquifer.version;
+        this.config.version = this.config.version || this.aquifer.version;
 
         // If a config json path was passed in, extend the default.
         if (configJsonPath) {

--- a/lib/project.api.js
+++ b/lib/project.api.js
@@ -29,7 +29,7 @@ class Project {
   constructor(Aquifer, drupalVersion) {
     // Scaffold class properties.
     this.aquifer = Aquifer;
-    this.config = {};
+    this.config = this.aquifer.initialConfig;
     this.paths = {};
     this.absolutePaths = {};
     this.drupalVersion = drupalVersion || 7;
@@ -55,36 +55,10 @@ class Project {
    */
   initialize(directory, name, configJsonPath) {
     return new Promise((resolve, reject) => {
-      // Calculate paths to json, and source directory.
       let jsonPath = path.join(directory, 'aquifer.json');
 
-      let localJsonPath = path.join(directory, 'aquifer.local.json');
-
-
-
       // Default directory to Aquifer.projectDir.
-      this.directory = directory = directory || Aquifer.projectDir;
-
-      // If this project is initialized, load the JSON path.
-      if (this.aquifer.initialized) {
-        this.config = jsonFile.readFileSync(jsonPath);
-
-        // Extend config with aquifer.local.json.
-        if (fs.existsSync(localJsonPath)) {
-          this.config = _.defaultsDeep(jsonFile.readFileSync(localJsonPath), this.config);
-        }
-      }
-
-      // If this is a new (uninitialized) project, load the default json.
-      else {
-        this.config = jsonFile.readFileSync(path.join(this.srcDir, 'aquifer.default.json'));
-
-        // If a config json path was passed in, extend the default.
-        if (configJsonPath) {
-          var configJson = jsonFile.readFileSync(configJsonPath);
-          _.merge(this.config, configJson);
-        }
-      }
+      this.directory = directory = directory || this.aquifer.projectDir;
 
       // Set name, default to basename of directory.
       if (!this.config.name || this.config.name.length <= 0) {

--- a/src/d7/package.json
+++ b/src/d7/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aquifer",
+  "name": "aquifer-project-dependencies",
   "version": "0.1.4",
   "description": "Drupal build, test, and deployment CLI.",
   "license": "GPL-2.0",

--- a/src/d8/package.json
+++ b/src/d8/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aquifer",
+  "name": "aquifer-project-dependencies",
   "version": "0.1.4",
   "description": "Drupal build, test, and deployment CLI.",
   "license": "GPL-2.0",


### PR DESCRIPTION
Issue: #163

This PR adds an NPM API and uses it to install and use the version of aquifer specified in aquifer.json when aquifer is invoked within that project.
## @TODO:
- [x] Use the NPM API in the extensions API.
- [x] Dynamically insert the "version" property when creating a new project with the current version of the aquifer being executed.
- [x] Handle versions more flexibly. Right now it will only accept tags, versions, or version ranges. No Github branches or locally linked modules.
