### PR TITLE
Extension config subproperty

### DIFF
--- a/lib/extension.api.js
+++ b/lib/extension.api.js
@@ -52,17 +52,17 @@ class Extension {
       // Download this extension.
       this.download()
 
-        // Update extensions object in aquifer.json.
-        .then(() => {
-          let extensions = this.aquifer.project.config.extensions;
-          extensions[this.name] = { source: this.source };
-          this.aquifer.project.updateJson({
-            extensions: extensions
-          });
+      // Update extensions object in aquifer.json.
+      .then(() => {
+        let extensions = this.aquifer.project.config.extensions;
+        extensions[this.name] = { source: this.source };
+        this.aquifer.project.updateJson({
+          extensions: extensions
+        });
 
-          this.loadConfig();
-          resolve();
-        })
+        this.loadConfig();
+        resolve();
+      })
     })
   }
 

--- a/lib/extension.api.js
+++ b/lib/extension.api.js
@@ -159,10 +159,10 @@ class Extension {
    */
   loadConfig() {
     this.path = path.join(this.aquifer.projectDir, '.aquifer/node_modules/' + this.name);
-    this.source = this.aquifer.project.config.extensions[this.name].hasOwnProperty('source') ? this.aquifer.project.config.extensions[this.name].source : false;
-    this.config = this.aquifer.project.config.extensions[this.name].hasOwnProperty('config') ? this.aquifer.project.config.extensions[this.name].config : {};
-    this.installed = !!this.aquifer.project.config.extensions.hasOwnProperty(this.name);
     this.downloaded = !!this.pathExists(this.path);
+    this.installed = !!this.aquifer.project.config.extensions.hasOwnProperty(this.name);
+    this.source = (this.installed && this.aquifer.project.config.extensions[this.name].hasOwnProperty('source')) ? this.aquifer.project.config.extensions[this.name].source : false;
+    this.config = (this.installed && this.aquifer.project.config.extensions[this.name].hasOwnProperty('config')) ? this.aquifer.project.config.extensions[this.name].config : {};
   }
 
   /**

--- a/lib/extension.api.js
+++ b/lib/extension.api.js
@@ -32,14 +32,10 @@ class Extension {
     // Load config.
     this.loadConfig();
 
-    // If this is installed, load the source from config.
-    if (this.installed) {
-      this.source = this.config.source;
-    }
     // If this package is not installed, use passed in source param.
     // If none is passed in, default to name property.
     // (npm install /path/to/module || npm install published-module-name)
-    else {
+    if (!this.installed) {
       this.source = source || this.name;
     }
 
@@ -56,17 +52,17 @@ class Extension {
       // Download this extension.
       this.download()
 
-      // Update extensions object in aquifer.json.
-      .then(() => {
-        let extensions = this.aquifer.project.config.extensions;
-        extensions[this.name] = { source: this.source };
-        this.aquifer.project.updateJson({
-          extensions: extensions
-        });
+        // Update extensions object in aquifer.json.
+        .then(() => {
+          let extensions = this.aquifer.project.config.extensions;
+          extensions[this.name] = { source: this.source };
+          this.aquifer.project.updateJson({
+            extensions: extensions
+          });
 
-        this.loadConfig();
-        resolve();
-      })
+          this.loadConfig();
+          resolve();
+        })
     })
   }
 
@@ -163,9 +159,10 @@ class Extension {
    */
   loadConfig() {
     this.path = path.join(this.aquifer.projectDir, '.aquifer/node_modules/' + this.name);
-    this.config = this.aquifer.project.config.extensions.hasOwnProperty(this.name) ? this.aquifer.project.config.extensions[this.name] : false;
-    this.installed = this.config ? true : false;
-    this.downloaded = this.pathExists(this.path) ? true : false;
+    this.source = this.aquifer.project.config.extensions[this.name].hasOwnProperty('source') ? this.aquifer.project.config.extensions[this.name].source : false;
+    this.config = this.aquifer.project.config.extensions[this.name].hasOwnProperty('config') ? this.aquifer.project.config.extensions[this.name].config : {};
+    this.installed = !!this.aquifer.project.config.extensions.hasOwnProperty(this.name);
+    this.downloaded = !!this.pathExists(this.path);
   }
 
   /**


### PR DESCRIPTION
Fixes: https://github.com/aquifer/aquifer/issues/62

**To test:**
- [x] `aquifer create test && cd test`
- [x] `aquifer extension-add aquifer-git -s git://github.com/aquifer/aquifer-git.git#1.0.0`
- [x] Add the following config to the extensions object in `aquifer.json`:
  
  ```
    "aquifer-git": {
      "source": "git://github.com/aquifer/aquifer-git.git#1.0.0",
      "config": {
        "remote": "user@agitrepositoryhost.com:repositoryname.git",
        "branch": "master",
        "folder": "docroot",
        "name": "Deploy Bot",
        "email": "deploybot@aquifer.io",
        "deploymentFiles": [
          {
            "src": "deploy/.gitignore",
            "dest": ".gitignore"
          },
          {
            "src": "deploy/.htaccess",
            "dest": ".htaccess"
          }
        ],
        "excludeLinks": ["sites/default/files"],
        "addLinks": [
          {
            "src": "path/to/dir/in/project",
            "dest": "path/to/dir/in/build",
            "type": "dir"
          }
        ],
        "delPatterns": ["*", "!.git"]
      }
    }
  ```
- [x] Run `aquifer deploy-git`
- [x] You will get an error:
  
  > ssh: Could not resolve hostname agitrepositoryhost.com: nodename nor servname provided, or not known
  > fatal: Could not read from remote repository.
  
  ...but this is okay because it shows it is reading the bogus git remote value from within the `config` subproperty.
