### PR TITLE
Bump version to r1.0.0-beta3

### DIFF
--- a/lib/aquifer.api.js
+++ b/lib/aquifer.api.js
@@ -24,7 +24,7 @@ class Aquifer {
    * @returns {undefined} nothing.
    */
   constructor() {
-    this.version = '1.0.0-beta2';
+    this.version = '1.0.0-beta3';
     this.cli = require('commander');
     this.cwd = process.cwd();
     this.initialized = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquifer",
-  "version": "1.0.0-beta2",
+  "version": "1.0.0-beta3",
   "description": "Drupal build, test, and deployment CLI.",
   "scripts": {
     "test-unit": "node_modules/.bin/mocha test/unit/*",


### PR DESCRIPTION
This PR just bumps Aquifers version from 1.0.0-beta2 to 1.0.0-beta3.
