### PR TITLE
Arrays in aquifler.local.json should overwrite those in aquifer.json

### DIFF
--- a/lib/aquifer.api.js
+++ b/lib/aquifer.api.js
@@ -11,6 +11,13 @@ const fs = require('fs-extra');
 const spawn = require('child_process').spawn;
 const jsonFile = require('jsonfile');
 const path = require('path');
+const mergeDefaults = require('merge-defaults');
+
+// Allow for deepDefaults without merging arrays. This is useful for run
+// scripts defined in aquifer.local.json. The expected behavior is that a run
+// script in aquifer.local.json should completely overwrite a script of the same
+// name in aquifer.json. The regular deepDefaults method merges the two arrays.
+_.mixin({'defaultsDeepNoArrays': mergeDefaults});
 
 /**
  * Constructs a main Aquifer project.
@@ -205,7 +212,8 @@ class Aquifer {
 
         // Extend config with aquifer.local.json.
         if (fs.existsSync(localJsonPath)) {
-          this.initialConfig = _.defaultsDeep(jsonFile.readFileSync(localJsonPath), this.initialConfig);
+
+          this.initialConfig = _.defaultsDeepNoArrays(jsonFile.readFileSync(localJsonPath), this.initialConfig);
         }
       }
 

--- a/lib/run.api.js
+++ b/lib/run.api.js
@@ -9,6 +9,7 @@
 const spawn = require('child_process').spawn;
 const parseArgs = require('parse-spawn-args').parse;
 const ssh = require('ssh2');
+const fs = require('fs-extra');
 
 /**
  * Constructs the run API for Aquifer.
@@ -42,6 +43,10 @@ class Run {
 
     return new Promise((resolve, reject) => {
       command = this.parse(command);
+
+      if (options.hasOwnProperty('cwd') && !fs.existsSync(options.cwd)) {
+        reject('Trying to run a command from a location which does not exist: ' + options.cwd);
+      }
 
       let child = spawn(command.name, command.args, options);
 

--- a/lib/run.api.js
+++ b/lib/run.api.js
@@ -36,6 +36,8 @@ class Run {
    * @returns {object} promise object.
    */
   invoke(command, options, env) {
+    options = options || {};
+
     // Invoke on an environment.
     if (typeof env !== 'undefined') {
       return this.invokeOnEnv(command, env);
@@ -128,6 +130,8 @@ class Run {
    * @returns {object} promise object.
    */
   invokeAll(commands, options, env) {
+    options = options || {};
+
     // Invoke on an environment.
     if (typeof env !== 'undefined') {
       return this.invokeOnEnv(commands, env);

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "inquirer": "^0.11.4",
     "jsonfile": "^2.0.0",
     "lodash": "^3.6.0",
+    "merge-defaults": "^0.2.1",
     "parse-spawn-args": "^1.0.2",
     "path": "^0.11.14",
     "ssh2": "^0.4.13",


### PR DESCRIPTION
We should put some substantial testing into this to make sure this doesn't cause issues with some other config property defined in aquifer.local.json. In my testing so far it behaves as it should.

You can test this with the following method:
- [ ] Add this to your aquifer.json:
  
  ``` json
  "run": {
    "scripts": {
      "hello": [
        "echo 1",
        "echo 2",
        "echo 3",
        "echo 4",
        "echo 5"
      ]
    }
  }
  ```
- [ ] Add this to your aquifer.local.json:
  
  ``` json
  "run": {
    "scripts": {
        "hello": [
          "echo A",
          "echo B",
          "echo C"
        ]
      }
  }
  ```
- [ ] Run `aquifer run hello`
- [ ] See the output is:
  
  ```
  A
  B
  C
  ```
- [ ] Try out a number of other config overrides in aquifer.local.json and make sure they all do what you expect.
