### PR TITLE
Don't check for makefile before prebuild sync.

### DIFF
--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -105,7 +105,7 @@ class Build {
         try {
           fs.statSync(this.options.makeFile);
         }
-          // If there was an exception, the make file probably doesn't exist.
+        // If there was an exception, the make file probably doesn't exist.
         catch (error) {
           reject(error);
           return;

--- a/lib/build.api.js
+++ b/lib/build.api.js
@@ -73,16 +73,6 @@ class Build {
       this.options.makeFile = project.absolutePaths.make;
       this.options.buildMethod = this.options.buildMethod || project.config.build.method;
 
-      // Make sure the make file exists.
-      try {
-        fs.statSync(this.options.makeFile);
-      }
-      // If there was an exception, the make file probably doesn't exist.
-      catch (error) {
-        reject(error);
-        return;
-      }
-
       // If the destination does not exist (was deleted or first build) create.
       if (!fs.existsSync(this.destination)) {
         fs.mkdirSync(this.destination);
@@ -110,6 +100,16 @@ class Build {
       .then(() => {
         let command = '';
         let commandOptions = {};
+
+        // Make sure the make file exists.
+        try {
+          fs.statSync(this.options.makeFile);
+        }
+          // If there was an exception, the make file probably doesn't exist.
+        catch (error) {
+          reject(error);
+          return;
+        }
 
         // TODO: Defer to a "build plugin" to run the command needed.
         if (this.options.buildMethod === 'drush make') {


### PR DESCRIPTION
Checking for the existence of the make file before the preBuild sync might be premature as the makefile might be moved into it's desired location during the preBuild sync.

This PR simply moves the check for the makefile to run inside the build promise (i.e. after the preBuild sync) and right before the build command (e.g. `composer install`) is defined and executed.
