### PR TITLE
Allow source property to be handled properly

### DIFF
--- a/lib/aquifer.api.js
+++ b/lib/aquifer.api.js
@@ -247,8 +247,20 @@ class Aquifer {
         return;
       }
 
-      let source = this.initialConfig.source || 'aquifer@' + this.initialConfig.version;
+      // Ensure .aquifer/package.json file exists.
+      let projectAquiferPackageJson = path.join(this.projectDir, '.aquifer/package.json');
 
+      if (!fs.existsSync(projectAquiferPackageJson)) {
+        let projectAquiferDir = path.join(this.projectDir, '.aquifer');
+
+        if (!fs.existsSync(projectAquiferDir)) {
+          fs.mkdirsSync(projectAquiferDir);
+        }
+
+        fs.writeFileSync(projectAquiferPackageJson, '{}');
+      }
+
+      let source = this.initialConfig.source || 'aquifer@' + this.initialConfig.version;
       let newAquifer = new this.api.npm(this, 'aquifer', source);
 
       if (newAquifer.installed) {
@@ -273,7 +285,7 @@ class Aquifer {
         }
 
         // Let the user know we'll be installing the specified version of aquifer now.
-        this.console.log('Aquifer ' + this.initialConfig.version + ' is not installed. Installing now...');
+        this.console.log('Aquifer ' + this.initialConfig.version + ' from ' + source + ' is not installed. Installing now...');
 
         newAquifer.install()
         .then(() => {

--- a/lib/aquifer.api.js
+++ b/lib/aquifer.api.js
@@ -231,7 +231,18 @@ class Aquifer {
         return;
       }
 
-      if (this.initialConfig.version === this.version) {
+      let aquiferDir = fs.realpathSync(path.join(path.dirname(module.parent.filename), '..'));
+
+      // Skip if this is already being run from the project level Aquifer.
+      if (path.basename(path.join(aquiferDir, '../../')) === '.aquifer') {
+        resolve();
+        return;
+      }
+
+      // Skip if we don't have a source property and local and project Aquifer
+      // versions match.
+      if (!this.initialConfig.hasOwnProperty('source')
+        && this.initialConfig.version === this.version) {
         resolve();
         return;
       }
@@ -242,7 +253,6 @@ class Aquifer {
 
       if (newAquifer.installed) {
         let newAquiferDir = fs.realpathSync(path.join(newAquifer.path));
-        let aquiferDir = fs.realpathSync(path.join(path.dirname(module.parent.filename), '..'));
 
         // Since the child aquifer module is installed, if the child module and
         // this current instance of aquifer have the same directory, then we are


### PR DESCRIPTION
Ensures installation of project level Aquifer works as expected when specifying a source.

To test: 
- [ ] Run `aquifer create test && cd test`
- [ ] Add to your `aquifer.json`:
```
{
  "source": "aquifer/aquifer#handle-source-property",
  "version": "1.0.0-beta3"
}
```
- [ ] Run `aquifer` and verify that branch is downloaded into your project.
- [ ] Verify subsequent `aquifer` calls behave as expected.
