### PR TITLE
184 Fix: Node v4.7.2 support.

### DIFF
--- a/lib/npm.api.js
+++ b/lib/npm.api.js
@@ -72,9 +72,9 @@ class Npm {
         return;
       }
 
-      args = args || [];
+      args = Array.isArray(args)? args : [];
 
-      let npmModule = require(this.path)(...args) || false;
+      let npmModule = require(this.path).apply(null, args) || false;
       resolve(npmModule);
     })
   };


### PR DESCRIPTION
The array spread function was breaking because it is only supported in v4 with special flags (http://stackoverflow.com/questions/17379277/destructuring-in-node-js) though it is supported for v6 or with babel.  This should have very much the same effect as before but without breaking syntax. Without tests its really hard to say if this will break anything but it is working locally.