### PR TITLE
Enforcing Commander Dependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/aquifer/aquifer",
   "dependencies": {
     "chalk": "^1.0.0",
-    "commander": "^2.7.1",
+    "commander": ">=2.7.1 <=2.9.0",
     "del": "^1.2.1",
     "fs-extra": "^0.30.0",
     "inquirer": "^0.11.4",


### PR DESCRIPTION
Enforcing Commander dependencies as the new version 2.11.0 breaks things.

This was determined from new environments set up where aquifer was installed and received the error message

```
$ ./node_modules/.bin/aquifer build
"build" is an invalid command or flag.
```

I determined that on line 165, `command[0] in this.cli._events` evaluated to false for commander 2.11.0. We knew that 2.9.0 worked from an older build of 1.0.0-beta3 so went with that.
